### PR TITLE
Improve HLS support

### DIFF
--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -20,7 +20,7 @@ use cpal::{Stream, traits::{HostTrait, DeviceTrait, StreamTrait}, Device, Stream
 use rb::{Producer, Consumer, SpscRb, RB, RbConsumer, RbProducer};
 use symphonia::core::audio::{SignalSpec, SampleBuffer, AudioBufferRef};
 
-use super::{controls::*, dsp::{resampler::Resampler, normalizer::Normalizer}, streaming::http::IS_STREAM_BUFFERING};
+use super::{controls::*, dsp::{resampler::Resampler, normalizer::Normalizer}, streaming::streamable::IS_STREAM_BUFFERING};
 
 /// The default output volume is way too high.
 /// Multiplying the volume input by this number

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -20,7 +20,7 @@ use cpal::{Stream, traits::{HostTrait, DeviceTrait, StreamTrait}, Device, Stream
 use rb::{Producer, Consumer, SpscRb, RB, RbConsumer, RbProducer};
 use symphonia::core::audio::{SignalSpec, SampleBuffer, AudioBufferRef};
 
-use super::{controls::*, dsp::{resampler::Resampler, normalizer::Normalizer}, streamable_file::IS_STREAM_BUFFERING};
+use super::{controls::*, dsp::{resampler::Resampler, normalizer::Normalizer}, streaming::http::IS_STREAM_BUFFERING};
 
 /// The default output volume is way too high.
 /// Multiplying the volume input by this number

--- a/rust/src/audio/streaming/hls.rs
+++ b/rust/src/audio/streaming/hls.rs
@@ -13,9 +13,3 @@
 //
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <https://www.gnu.org/licenses/>.
-
-pub mod decoder;
-pub mod controls;
-pub mod streaming;
-mod cpal_output;
-mod dsp;

--- a/rust/src/audio/streaming/hls.rs
+++ b/rust/src/audio/streaming/hls.rs
@@ -13,3 +13,247 @@
 //
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <https://www.gnu.org/licenses/>.
+
+use std::io::{Read, Seek};
+use std::thread;
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+use rangemap::RangeSet;
+use reqwest::blocking::Client;
+use symphonia::core::io::MediaSource;
+
+use super::streamable::*;
+
+pub struct HlsStream
+{
+    url:String,
+    buffer:Vec<u8>,
+    read_position:usize,
+    downloaded:RangeSet<usize>,
+    requested:RangeSet<usize>,
+    receivers:Vec<(u128, Receiver<(usize, Vec<u8>)>)>
+}
+
+impl HlsStream
+{
+    pub fn new(url:String) -> Self
+    {
+        // Get the size of the file we are streaming.
+        let res = Client::new().head(&url)
+            .send()
+            .unwrap();
+
+        let header = res
+            .headers().get("Content-Length")
+            .unwrap();
+
+        let size:usize = header
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+
+            HlsStream
+        {
+            url,
+            buffer: vec![0; size],
+            read_position: 0,
+            downloaded: RangeSet::new(),
+            requested: RangeSet::new(),
+            receivers: Vec::new()
+        }
+    }
+}
+
+impl Streamable<Self> for HlsStream
+{
+    /// Gets the next chunk in the sequence.
+    /// 
+    /// Returns the received bytes by sending them via `tx`.
+    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize)
+    {
+        let end = (start + CHUNK_SIZE).min(file_size) - 1;
+
+        let chunk = Client::new().get(url)
+            .header("Range", format!("bytes={start}-{end}"))
+            .send().unwrap().bytes().unwrap().to_vec();
+        
+        tx.send((start, chunk)).unwrap();
+    }
+
+    /// Polls all receivers.
+    /// 
+    /// If there is data to receive, then write it to the buffer.
+    /// 
+    /// Changes made are commited to `downloaded`.
+    fn try_write_chunk(&mut self, should_buffer:bool)
+    {
+        let mut completed_downloads = Vec::new();
+
+        for (id, rx) in &self.receivers
+        {
+            // Block on the first chunk or when buffering.
+            // Buffering fixes the issue with seeking on MP3 (no blocking on data).
+            let result = if self.downloaded.is_empty() || should_buffer {
+                rx.recv().ok()
+            } else { rx.try_recv().ok() };
+
+            match result
+            {
+                None => (),
+                Some((position, chunk)) => {
+                    // Write the data.
+                    let end = (position + chunk.len()).min(self.buffer.len());
+
+                    if position != end {
+                        self.buffer[position..end].copy_from_slice(chunk.as_slice());
+                        self.downloaded.insert(position..end);
+                    }
+
+                    // Clean up.
+                    completed_downloads.push(*id);
+                }
+            }
+        }
+
+        // Remove completed receivers.
+        self.receivers.retain(|(id, _)| !completed_downloads.contains(&id));
+    }
+
+    /// Determines if a chunk should be downloaded by getting
+    /// the downloaded range that contains `self.read_position`.
+    /// 
+    /// Returns `true` and the start index of the chunk
+    /// if one should be downloaded.
+    fn should_get_chunk(&self) -> (bool, usize)
+    {
+        let closest_range = self.downloaded.get(&self.read_position);
+
+        if closest_range.is_none() {
+            return (true, self.read_position);
+        }
+
+        let closest_range = closest_range.unwrap();
+        
+        // Make sure that the same chunk isn't being downloaded again.
+        // This may happen because the next `read` call happens
+        // before the chunk has finished downloading. In that case,
+        // it is unnecessary to request another chunk.
+        let is_already_downloading = self.requested.contains(&(self.read_position + CHUNK_SIZE));
+
+        // Basically, if the condition below is true,
+        // then a chunk needs to be downloaded to ensure
+        // that there are at least 2 chunks ahead of the read_position.
+        // This reduces buffering in the FLAC and OGG formats.
+        let prefetch_pos = self.read_position + (CHUNK_SIZE * 2);
+
+        let should_get_chunk = prefetch_pos >= closest_range.end
+            && !is_already_downloading
+            && closest_range.end != self.buffer.len();
+        
+        (should_get_chunk, closest_range.end)
+    }
+}
+
+impl Read for HlsStream
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>
+    {
+        // If we are reading after the buffer,
+        // then return early with 0 written bytes.
+        if self.read_position >= self.buffer.len() {
+            return Ok(0);
+        }
+
+        // This defines the end position of the packet
+        // we want to read.
+        let read_max = (self.read_position + buf.len()).min(self.buffer.len());
+
+        // If the position we are reading at is close
+        // to the last downloaded chunk, then fetch more.
+        let (should_get_chunk, chunk_write_pos) = self.should_get_chunk();
+        
+        // println!("Read: read_pos[{}] read_max[{read_max}] buf[{}] write_pos[{chunk_write_pos}] download[{should_get_chunk}]", self.read_position, buf.len());
+        if should_get_chunk
+        {
+            self.requested.insert(chunk_write_pos..chunk_write_pos + CHUNK_SIZE + 1);
+
+            let url = self.url.clone();
+            let file_size = self.buffer.len();
+            let (tx, rx) = channel();
+
+            let id = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)
+                .unwrap().as_millis();
+            self.receivers.push((id, rx));
+
+            thread::spawn(move || {
+                Self::read_chunk(tx, url, chunk_write_pos, file_size);
+            });
+        }
+
+        // Write any new bytes.
+        let should_buffer = !self.downloaded.contains(&self.read_position);
+        IS_STREAM_BUFFERING.store(should_buffer, std::sync::atomic::Ordering::SeqCst);
+        self.try_write_chunk(should_buffer);
+
+        // These are the bytes that we want to read.
+        let bytes = &self.buffer[self.read_position..read_max];
+        buf[0..bytes.len()].copy_from_slice(bytes);
+
+        self.read_position += bytes.len();
+        Ok(bytes.len())
+    }
+}
+
+impl Seek for HlsStream
+{
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64>
+    {
+        let seek_position:usize = match pos
+        {
+            std::io::SeekFrom::Start(pos) => pos as usize,
+            std::io::SeekFrom::Current(pos) => {
+                let pos = self.read_position as i64 + pos;
+                pos.try_into().map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput, 
+                        format!("Invalid seek: {pos}")
+                    )
+                })?
+            },
+            std::io::SeekFrom::End(pos) => {
+                let pos = self.buffer.len() as i64 + pos;
+                pos.try_into().map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput, 
+                        format!("Invalid seek: {pos}")
+                    )
+                })?
+            },
+        };
+
+        if seek_position > self.buffer.len() {
+            return Ok(self.read_position as u64);
+        }
+
+        // println!("Seeking: pos[{seek_position}] type[{pos:?}]");
+
+        self.read_position = seek_position;
+
+        Ok(seek_position as u64)
+    }
+}
+
+unsafe impl Send for HlsStream {}
+unsafe impl Sync for HlsStream {}
+
+impl MediaSource for HlsStream
+{
+    fn is_seekable(&self) -> bool {
+        true
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        Some(self.buffer.len() as u64)
+    }
+}

--- a/rust/src/audio/streaming/hls.rs
+++ b/rust/src/audio/streaming/hls.rs
@@ -165,9 +165,10 @@ impl Read for HlsStream
 
             if let Some((range, url)) = part
             {
-                self.requested.insert(chunk_write_pos..chunk_write_pos + range.clone().count() + 1);
+                self.requested.insert(range.clone());
 
                 let url = url.clone();
+                let start = range.start;
                 let file_size = self.buffer.len();
                 let (tx, rx) = channel();
 
@@ -176,7 +177,7 @@ impl Read for HlsStream
                 self.receivers.push((id, rx));
 
                 thread::spawn(move || {
-                    Self::read_chunk(tx, url, chunk_write_pos, file_size);
+                    Self::read_chunk(tx, url, start, file_size);
                 });
 
                 // Because the sizes of the parts vary, `should_get_chunk` may

--- a/rust/src/audio/streaming/http.rs
+++ b/rust/src/audio/streaming/http.rs
@@ -16,7 +16,7 @@
 
 use std::io::{Read, Seek};
 use std::thread;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{channel, Receiver};
 
 use rangemap::RangeSet;
 use reqwest::blocking::Client;
@@ -67,20 +67,6 @@ impl HttpStream
 
 impl Streamable<Self> for HttpStream
 {
-    /// Gets the next chunk in the sequence.
-    /// 
-    /// Returns the received bytes by sending them via `tx`.
-    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize)
-    {
-        let end = (start + CHUNK_SIZE).min(file_size) - 1;
-
-        let chunk = Client::new().get(url)
-            .header("Range", format!("bytes={start}-{end}"))
-            .send().unwrap().bytes().unwrap().to_vec();
-        
-        tx.send((start, chunk)).unwrap();
-    }
-
     /// Polls all receivers.
     /// 
     /// If there is data to receive, then write it to the buffer.

--- a/rust/src/audio/streaming/http.rs
+++ b/rust/src/audio/streaming/http.rs
@@ -16,7 +16,7 @@
 
 use std::io::{Read, Seek};
 use std::thread;
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::{channel, Receiver, Sender};
 
 use rangemap::RangeSet;
 use reqwest::blocking::Client;
@@ -67,6 +67,20 @@ impl HttpStream
 
 impl Streamable<Self> for HttpStream
 {
+    /// Gets the next chunk in the sequence.
+    /// 
+    /// Returns the received bytes by sending them via `tx`.
+    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize)
+    {
+        let end = (start + CHUNK_SIZE).min(file_size) - 1;
+
+        let chunk = Client::new().get(url)
+            .header("Range", format!("bytes={start}-{end}"))
+            .send().unwrap().bytes().unwrap().to_vec();
+        
+        tx.send((start, chunk)).unwrap();
+    }
+
     /// Polls all receivers.
     /// 
     /// If there is data to receive, then write it to the buffer.

--- a/rust/src/audio/streaming/http.rs
+++ b/rust/src/audio/streaming/http.rs
@@ -28,7 +28,7 @@ pub static IS_STREAM_BUFFERING:AtomicBool = AtomicBool::new(false);
 
 const CHUNK_SIZE:usize = 1024 * 128;
 
-pub struct StreamableFile
+pub struct HttpStream
 {
     url:String,
     buffer:Vec<u8>,
@@ -38,7 +38,7 @@ pub struct StreamableFile
     receivers:Vec<(u128, Receiver<(usize, Vec<u8>)>)>
 }
 
-impl StreamableFile
+impl HttpStream
 {
     pub fn new(url:String) -> Self
     {
@@ -57,7 +57,7 @@ impl StreamableFile
             .parse()
             .unwrap();
 
-        StreamableFile
+        HttpStream
         {
             url,
             buffer: vec![0; size],
@@ -156,7 +156,7 @@ impl StreamableFile
     }
 }
 
-impl Read for StreamableFile
+impl Read for HttpStream
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>
     {
@@ -206,7 +206,7 @@ impl Read for StreamableFile
     }
 }
 
-impl Seek for StreamableFile
+impl Seek for HttpStream
 {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64>
     {
@@ -245,10 +245,10 @@ impl Seek for StreamableFile
     }
 }
 
-unsafe impl Send for StreamableFile {}
-unsafe impl Sync for StreamableFile {}
+unsafe impl Send for HttpStream {}
+unsafe impl Sync for HttpStream {}
 
-impl MediaSource for StreamableFile
+impl MediaSource for HttpStream
 {
     fn is_seekable(&self) -> bool {
         true

--- a/rust/src/audio/streaming/http.rs
+++ b/rust/src/audio/streaming/http.rs
@@ -15,7 +15,6 @@
 // If not, see <https://www.gnu.org/licenses/>.
 
 use std::io::{Read, Seek};
-use std::sync::atomic::AtomicBool;
 use std::thread;
 use std::sync::mpsc::{channel, Receiver, Sender};
 
@@ -23,10 +22,7 @@ use rangemap::RangeSet;
 use reqwest::blocking::Client;
 use symphonia::core::io::MediaSource;
 
-// Used in cpal_output.rs to mute the stream when buffering.
-pub static IS_STREAM_BUFFERING:AtomicBool = AtomicBool::new(false);
-
-const CHUNK_SIZE:usize = 1024 * 128;
+use super::streamable::*;
 
 pub struct HttpStream
 {
@@ -67,7 +63,10 @@ impl HttpStream
             receivers: Vec::new()
         }
     }
+}
 
+impl Streamable<Self> for HttpStream
+{
     /// Gets the next chunk in the sequence.
     /// 
     /// Returns the received bytes by sending them via `tx`.

--- a/rust/src/audio/streaming/mod.rs
+++ b/rust/src/audio/streaming/mod.rs
@@ -16,3 +16,4 @@
 
 pub mod http;
 pub mod hls;
+pub mod streamable;

--- a/rust/src/audio/streaming/mod.rs
+++ b/rust/src/audio/streaming/mod.rs
@@ -14,8 +14,5 @@
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <https://www.gnu.org/licenses/>.
 
-pub mod decoder;
-pub mod controls;
-pub mod streaming;
-mod cpal_output;
-mod dsp;
+pub mod http;
+pub mod hls;

--- a/rust/src/audio/streaming/mod.rs
+++ b/rust/src/audio/streaming/mod.rs
@@ -17,3 +17,11 @@
 pub mod http;
 pub mod hls;
 pub mod streamable;
+
+/// A type that holds an ID and a `std::sync::mpsc::Receiver`.
+/// Used for multithreaded download of audio data.
+struct Receiver
+{
+    id: u128,
+    receiver: std::sync::mpsc::Receiver<(usize, Vec<u8>)>
+}

--- a/rust/src/audio/streaming/streamable.rs
+++ b/rust/src/audio/streaming/streamable.rs
@@ -24,7 +24,20 @@ pub const CHUNK_SIZE:usize = 1024 * 128;
 
 pub trait Streamable<T: Read + Seek + Send + Sync + MediaSource>
 {
-    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize);
+    /// Gets the next chunk in the sequence.
+    /// 
+    /// Returns the received bytes by sending them via `tx`.
+    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize)
+    {
+        let end = (start + CHUNK_SIZE).min(file_size) - 1;
+
+        let chunk = reqwest::blocking::Client::new().get(url)
+            .header("Range", format!("bytes={start}-{end}"))
+            .send().unwrap().bytes().unwrap().to_vec();
+        
+        tx.send((start, chunk)).unwrap();
+    }
+
     fn try_write_chunk(&mut self, should_buffer:bool);
     fn should_get_chunk(&self) -> (bool, usize);
 }

--- a/rust/src/audio/streaming/streamable.rs
+++ b/rust/src/audio/streaming/streamable.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <https://www.gnu.org/licenses/>.
 
-use std::{io::{Read, Seek}, sync::{mpsc::Sender, atomic::AtomicBool}};
+use std::{io::{Read, Seek}, sync::{atomic::AtomicBool, mpsc::Sender}};
 
 use symphonia::core::io::MediaSource;
 
@@ -24,20 +24,7 @@ pub const CHUNK_SIZE:usize = 1024 * 128;
 
 pub trait Streamable<T: Read + Seek + Send + Sync + MediaSource>
 {
-    /// Gets the next chunk in the sequence.
-    /// 
-    /// Returns the received bytes by sending them via `tx`.
-    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize)
-    {
-        let end = (start + CHUNK_SIZE).min(file_size) - 1;
-
-        let chunk = reqwest::blocking::Client::new().get(url)
-            .header("Range", format!("bytes={start}-{end}"))
-            .send().unwrap().bytes().unwrap().to_vec();
-        
-        tx.send((start, chunk)).unwrap();
-    }
-
+    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize);
     fn try_write_chunk(&mut self, should_buffer:bool);
     fn should_get_chunk(&self) -> (bool, usize);
 }

--- a/rust/src/audio/streaming/streamable.rs
+++ b/rust/src/audio/streaming/streamable.rs
@@ -1,0 +1,30 @@
+// This file is a part of simple_audio
+// Copyright (c) 2022-2023 Erikas Taroza <erikastaroza@gmail.com>
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with this program.
+// If not, see <https://www.gnu.org/licenses/>.
+
+use std::{io::{Read, Seek}, sync::{mpsc::Sender, atomic::AtomicBool}};
+
+use symphonia::core::io::MediaSource;
+
+// Used in cpal_output.rs to mute the stream when buffering.
+pub static IS_STREAM_BUFFERING:AtomicBool = AtomicBool::new(false);
+pub const CHUNK_SIZE:usize = 1024 * 128;
+
+pub trait Streamable<T: Read + Seek + Send + Sync + MediaSource>
+{
+    fn read_chunk(tx:Sender<(usize, Vec<u8>)>, url:String, start:usize, file_size:usize);
+    fn try_write_chunk(&mut self, should_buffer:bool);
+    fn should_get_chunk(&self) -> (bool, usize);
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -21,7 +21,7 @@ mod metadata;
 
 use std::{fs::File, io::Cursor, thread};
 
-use audio::{decoder::Decoder, controls::*, streaming::http::HttpStream};
+use audio::{decoder::Decoder, controls::*, streaming::{http::HttpStream, hls::HlsStream}};
 use crossbeam::channel::unbounded;
 use flutter_rust_bridge::StreamSink;
 use metadata::types::{Metadata, Actions};
@@ -123,9 +123,9 @@ impl Player
     pub fn open(&self, path:String, autoplay:bool)
     {
         let source:Box<dyn MediaSource> = if path.contains("http") {
-            if path.contains("m3u") { Box::new(Self::open_m3u(path)) }
+            // if path.contains("m3u") { Box::new(Self::open_m3u(path)) }
+            if path.contains("m3u") { Box::new(HlsStream::new(path)) }
             // Everything but m3u/m3u8
-            // else { Box::new(Cursor::new(Self::get_bytes_from_network(path))) }
             else { Box::new(HttpStream::new(path)) }
         } else { Box::new(File::open(path).unwrap()) };
 
@@ -290,6 +290,20 @@ mod tests
         // You can change the file extension here for different formats ------v
         // https://docs.espressif.com/projects/esp-adf/en/latest/design-guide/audio-samples.html
         player.open("https://dl.espressif.com/dl/audio/ff-16b-2c-44100hz.mp4".to_string(), true);
+        player.set_volume(0.1);
+        thread::sleep(Duration::from_secs(10));
+        println!("~~~~~~~~~~~~~~~~");
+        player.seek(90);
+        thread::sleep(Duration::from_secs(10));
+        player.seek(60);
+        thread::sleep(Duration::from_secs(187));
+    }
+
+    #[test]
+    fn open_hls_and_play()
+    {
+        let player = crate::Player::default();
+        player.open("https://cf-hls-media.sndcdn.com/playlist/x7uSGJp4rku7.128.mp3/playlist.m3u8?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL3BsYXlsaXN0L3g3dVNHSnA0cmt1Ny4xMjgubXAzL3BsYXlsaXN0Lm0zdTgqIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNjc1Njc0NDY2fX19XX0_&Signature=COdS6Qvk7rtCzl~zAj30D-BQU7br6bz2-gd~~E6rFge038ccjFAS9ZwtNFi1EhRoXEmSLcM-GZCy3bQieq5-qsjF4vR699cxnFJNIhKUiTbc~SRKhbW0U12W~-aNjyhTRoBCjj92ymLurUUA6k9FGY87oeL5Cmcd-ZbgHi-gzuCmCsp9cBwO5mjTyxks5TkPn8-S0cBMuBzJloOsarr~IxcqVoYv7yIx8rVwN6n8K75KPGhCAwakkfKkDBxLsPK0wQ25wFDeEtWviOu~DbPsfJUlxSGG6Y7DyimpDEOok6j-pGU9urOdhoVsY1NFblN-BPlKPLkgMVq-KmgSRB9A6g__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ".to_string(), true);
         player.set_volume(0.1);
         thread::sleep(Duration::from_secs(10));
         println!("~~~~~~~~~~~~~~~~");

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -21,7 +21,7 @@ mod metadata;
 
 use std::{fs::File, io::Cursor, thread};
 
-use audio::{decoder::Decoder, controls::*, streamable_file::StreamableFile};
+use audio::{decoder::Decoder, controls::*, streaming::http::HttpStream};
 use crossbeam::channel::unbounded;
 use flutter_rust_bridge::StreamSink;
 use metadata::types::{Metadata, Actions};
@@ -126,7 +126,7 @@ impl Player
             if path.contains("m3u") { Box::new(Self::open_m3u(path)) }
             // Everything but m3u/m3u8
             // else { Box::new(Cursor::new(Self::get_bytes_from_network(path))) }
-            else { Box::new(StreamableFile::new(path)) }
+            else { Box::new(HttpStream::new(path)) }
         } else { Box::new(File::open(path).unwrap()) };
 
         IS_PLAYING.store(autoplay, std::sync::atomic::Ordering::SeqCst);


### PR DESCRIPTION
Currently, `simple_audio` plays an m3u file by downloading all the bytes of each part before starting playback. This is not desired. Using similar concepts to #2, HLS files will be streamed.