### PR TITLE
Hot Restart Support

### DIFF
--- a/android/src/main/kotlin/com/erikas/simple_audio/SimpleAudioPlugin.kt
+++ b/android/src/main/kotlin/com/erikas/simple_audio/SimpleAudioPlugin.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.StrictMode
 import android.support.v4.media.session.PlaybackStateCompat
-import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -31,13 +30,13 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-var simpleAudioService:SimpleAudioService? = null
+var simpleAudioService: SimpleAudioService? = null
 
 /// The MethodChannel that will the communication between Flutter and native Android
 ///
 /// This local reference serves to register the plugin with the Flutter Engine and unregister it
 /// when the Flutter Engine is detached from the Activity
-var channel:MethodChannel? = null
+var channel: MethodChannel? = null
 
 /** SimpleAudioPlugin */
 class SimpleAudioPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
@@ -45,7 +44,7 @@ class SimpleAudioPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     private var appContext: Context? = null
     private var appActivity: Activity? = null
 
-    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding)
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding)
     {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "simple_audio")
         channel?.setMethodCallHandler(this)
@@ -58,7 +57,7 @@ class SimpleAudioPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
         appContext = flutterPluginBinding.applicationContext
     }
 
-    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding)
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding)
     {
         channel?.setMethodCallHandler(null)
         channel = null
@@ -74,7 +73,7 @@ class SimpleAudioPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) { }
     override fun onDetachedFromActivity() { }
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "init" -> {
                 if(call.argument<Boolean>("showMediaNotification") == false) return
@@ -91,6 +90,10 @@ class SimpleAudioPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
                 }
 
                 appContext?.startService(intent)
+            }
+            "dispose" -> {
+                simpleAudioService?.exitProcessOnDestroy = false
+                simpleAudioService?.kill()
             }
             "setMetadata" -> {
                 simpleAudioService?.setMetadata(

--- a/android/src/main/kotlin/com/erikas/simple_audio/SimpleAudioService.kt
+++ b/android/src/main/kotlin/com/erikas/simple_audio/SimpleAudioService.kt
@@ -45,6 +45,7 @@ class SimpleAudioService : MediaBrowserServiceCompat()
     private var playbackActions: List<PlaybackActions> = PlaybackActions.values().toList()
     private var compactPlaybackActions: List<Int> = listOf()
 
+    var exitProcessOnDestroy = true
     var isPlaying: Boolean = false
 
     override fun onGetRoot(
@@ -82,6 +83,7 @@ class SimpleAudioService : MediaBrowserServiceCompat()
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        exitProcessOnDestroy = true
         kill()
     }
 
@@ -99,7 +101,9 @@ class SimpleAudioService : MediaBrowserServiceCompat()
         // exit the process to prevent the foreground service from staying longer.
         // stopSelf/stopForeground don't work properly, so this is the only way.
         // Foreground service packages on Flutter do the same.
-        exitProcess(0)
+        // This will only be done when `onTaskRemoved` is called. The dispose method channel call
+        // will not kill the app.
+        if(exitProcessOnDestroy) exitProcess(0)
     }
 
     private fun getNotificationManager(): NotificationManager

--- a/darwin/Classes/SimpleAudio.swift
+++ b/darwin/Classes/SimpleAudio.swift
@@ -171,10 +171,11 @@ public class SimpleAudio
         commandCenter.skipBackwardCommand.isEnabled = false
         commandCenter.changePlaybackPositionCommand.isEnabled = false
 
-        #if os(macOS)
         let nowPlaying = MPNowPlayingInfoCenter.default()
-        nowPlaying.playbackState = MPNowPlayingPlaybackState.unknown
-        #endif
+        if #available(iOS 13.0, *) {
+            nowPlaying.playbackState = MPNowPlayingPlaybackState.unknown
+        }
+        nowPlaying.nowPlayingInfo = [:]
     }
     
     func setMetadata(

--- a/darwin/Classes/SimpleAudio.swift
+++ b/darwin/Classes/SimpleAudio.swift
@@ -26,12 +26,12 @@ import MediaPlayer
 @available(macOS 10.12.2, *)
 public class SimpleAudio
 {
-    var channel:FlutterMethodChannel
-    var currentMetadata:[String: Any] = [:]
+    var channel: FlutterMethodChannel
+    var currentMetadata: [String: Any] = [:]
     
-    var showMediaNotification:Bool = true
+    var showMediaNotification: Bool = true
 
-    init(channel:FlutterMethodChannel?)
+    init(channel: FlutterMethodChannel?)
     {
         self.channel = channel!
     }
@@ -41,7 +41,7 @@ public class SimpleAudio
         switch call.method
         {
             case "init":
-                let args:[String: Any] = call.arguments as! [String: Any]
+                let args: [String: Any] = call.arguments as! [String: Any]
             
                 showMediaNotification = args["showMediaNotification"] as! Bool
                 if(!showMediaNotification) { return }
@@ -50,8 +50,10 @@ public class SimpleAudio
                 let preferSkipButtons = args["preferSkipButtons"] as! Bool
             
                 initialize(actions: actions.map { try! Actions.fromInt(i: $0) }, preferSkipButtons: preferSkipButtons)
+            case "dispose":
+                dispose()
             case "setMetadata":
-                let args:[String: Any] = call.arguments as! [String: Any]
+                let args: [String: Any] = call.arguments as! [String: Any]
                     
                 if(!showMediaNotification) { return }
             
@@ -64,7 +66,7 @@ public class SimpleAudio
                     duration: args["duration"] as? Int
                 )
             case "setPlaybackState":
-                let args:[String: Any] = call.arguments as! [String: Any]
+                let args: [String: Any] = call.arguments as! [String: Any]
                     
                 if(!showMediaNotification) { return }
             
@@ -77,7 +79,7 @@ public class SimpleAudio
         }
     }
     
-    func initialize(actions:[Actions], preferSkipButtons:Bool)
+    func initialize(actions: [Actions], preferSkipButtons: Bool)
     {
         #if os(iOS)
         let session = AVAudioSession.sharedInstance()
@@ -153,13 +155,35 @@ public class SimpleAudio
         #endif
     }
     
+    func dispose()
+    {
+        #if os(iOS)
+        let session = AVAudioSession.sharedInstance()
+        try! session.setActive(false)
+        #endif
+
+        let commandCenter = MPRemoteCommandCenter.shared()
+        commandCenter.playCommand.isEnabled = false
+        commandCenter.pauseCommand.isEnabled = false
+        commandCenter.previousTrackCommand.isEnabled = false
+        commandCenter.nextTrackCommand.isEnabled = false
+        commandCenter.skipForwardCommand.isEnabled = false
+        commandCenter.skipBackwardCommand.isEnabled = false
+        commandCenter.changePlaybackPositionCommand.isEnabled = false
+
+        #if os(macOS)
+        let nowPlaying = MPNowPlayingInfoCenter.default()
+        nowPlaying.playbackState = MPNowPlayingPlaybackState.unknown
+        #endif
+    }
+    
     func setMetadata(
-        title:String?,
-        artist:String?,
-        album:String?,
-        artUri:String?,
-        artBytes:FlutterStandardTypedData?,
-        duration:Int?
+        title: String?,
+        artist: String?,
+        album: String?,
+        artUri: String?,
+        artBytes: FlutterStandardTypedData?,
+        duration: Int?
     )
     {
         currentMetadata = [
@@ -209,12 +233,12 @@ public class SimpleAudio
     }
     
     // See enum type PlaybackState in simple_audio.dart for integer values.
-    func setPlaybackState(state:Int?, position:Int?)
+    func setPlaybackState(state: Int?, position: Int?)
     {
         let nowPlaying = MPNowPlayingInfoCenter.default()
         
         #if os(macOS)
-        var translatedState:MPNowPlayingPlaybackState
+        var translatedState: MPNowPlayingPlaybackState
         
         switch(state)
         {
@@ -264,7 +288,7 @@ enum Actions
     case skipNext
     case fastForward
                 
-    static func fromInt(i:Int) throws -> Actions
+    static func fromInt(i: Int) throws -> Actions
     {
         switch(i)
         {

--- a/example/macos/Podfile
+++ b/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -255,6 +255,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -403,7 +404,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -425,7 +426,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -483,7 +484,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -530,7 +531,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -552,7 +553,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -573,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/ios/Classes/bridge_generated.h
+++ b/ios/Classes/bridge_generated.h
@@ -50,6 +50,8 @@ void wire_new__static_method__Player(int64_t port_,
                                      struct wire_uint_8_list *dbus_name,
                                      int64_t *hwnd);
 
+void wire_dispose__static_method__Player(int64_t port_);
+
 void wire_playback_state_stream__static_method__Player(int64_t port_);
 
 void wire_progress_state_stream__static_method__Player(int64_t port_);
@@ -100,6 +102,7 @@ void free_WireSyncReturn(WireSyncReturn ptr);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
     dummy_var ^= ((int64_t) (void*) wire_new__static_method__Player);
+    dummy_var ^= ((int64_t) (void*) wire_dispose__static_method__Player);
     dummy_var ^= ((int64_t) (void*) wire_playback_state_stream__static_method__Player);
     dummy_var ^= ((int64_t) (void*) wire_progress_state_stream__static_method__Player);
     dummy_var ^= ((int64_t) (void*) wire_callback_stream__static_method__Player);

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -16,6 +16,10 @@ abstract class SimpleAudio {
 
   FlutterRustBridgeTaskConstMeta get kNewStaticMethodPlayerConstMeta;
 
+  Future<void> disposeStaticMethodPlayer({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kDisposeStaticMethodPlayerConstMeta;
+
   Stream<PlaybackState> playbackStateStreamStaticMethodPlayer({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta
@@ -139,6 +143,9 @@ class Player {
           dynamic hint}) =>
       bridge.newStaticMethodPlayer(
           actions: actions, dbusName: dbusName, hwnd: hwnd, hint: hint);
+
+  static Future<void> dispose({required SimpleAudio bridge, dynamic hint}) =>
+      bridge.disposeStaticMethodPlayer(hint: hint);
 
   static Stream<PlaybackState> playbackStateStream(
           {required SimpleAudio bridge, dynamic hint}) =>

--- a/lib/src/bridge_generated.dart
+++ b/lib/src/bridge_generated.dart
@@ -48,6 +48,23 @@ class SimpleAudioImpl implements SimpleAudio {
         argNames: ["actions", "dbusName", "hwnd"],
       );
 
+  Future<void> disposeStaticMethodPlayer({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) =>
+          _platform.inner.wire_dispose__static_method__Player(port_),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kDisposeStaticMethodPlayerConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kDisposeStaticMethodPlayerConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "dispose__static_method__Player",
+        argNames: [],
+      );
+
   Stream<PlaybackState> playbackStateStreamStaticMethodPlayer({dynamic hint}) {
     return _platform.executeStream(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner
@@ -596,6 +613,20 @@ class SimpleAudioWire implements FlutterRustBridgeWireBase {
       _wire_new__static_method__PlayerPtr.asFunction<
           void Function(int, ffi.Pointer<wire_int_32_list>,
               ffi.Pointer<wire_uint_8_list>, ffi.Pointer<ffi.Int64>)>();
+
+  void wire_dispose__static_method__Player(
+    int port_,
+  ) {
+    return _wire_dispose__static_method__Player(
+      port_,
+    );
+  }
+
+  late final _wire_dispose__static_method__PlayerPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_dispose__static_method__Player');
+  late final _wire_dispose__static_method__Player =
+      _wire_dispose__static_method__PlayerPtr.asFunction<void Function(int)>();
 
   void wire_playback_state_stream__static_method__Player(
     int port_,

--- a/lib/src/simple_audio.dart
+++ b/lib/src/simple_audio.dart
@@ -199,7 +199,7 @@ class SimpleAudio
         bool applePreferSkipButtons = true
     }) async
     {
-        _dispose();
+        await _dispose();
 
         // You must include this action.
         if(showMediaNotification) assert(actions.contains(NotificationActions.playPause));
@@ -239,10 +239,9 @@ class SimpleAudio
     /// to its default state. Currently, the Rust code has some static
     /// variables that are used between the threads.
     /// These values would persist after a hot restart.
-    static void _dispose()
+    static Future<void> _dispose() async
     {
-        print("This is called at the right time.");
-        // Player.dispose();
+        await Player.dispose(bridge: api);
 
         // if(_usingNative) {
         //     _methodChannel.invokeMethod("dispose");

--- a/lib/src/simple_audio.dart
+++ b/lib/src/simple_audio.dart
@@ -243,9 +243,9 @@ class SimpleAudio
     {
         await Player.dispose(bridge: api);
 
-        // if(_usingNative) {
-        //     _methodChannel.invokeMethod("dispose");
-        // }
+        if(_usingNative) {
+            _methodChannel.invokeMethod("dispose");
+        }
     }
 
     /// Open a new file for playback.

--- a/macos/Classes/bridge_generated.h
+++ b/macos/Classes/bridge_generated.h
@@ -50,6 +50,8 @@ void wire_new__static_method__Player(int64_t port_,
                                      struct wire_uint_8_list *dbus_name,
                                      int64_t *hwnd);
 
+void wire_dispose__static_method__Player(int64_t port_);
+
 void wire_playback_state_stream__static_method__Player(int64_t port_);
 
 void wire_progress_state_stream__static_method__Player(int64_t port_);
@@ -100,6 +102,7 @@ void free_WireSyncReturn(WireSyncReturn ptr);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
     dummy_var ^= ((int64_t) (void*) wire_new__static_method__Player);
+    dummy_var ^= ((int64_t) (void*) wire_dispose__static_method__Player);
     dummy_var ^= ((int64_t) (void*) wire_playback_state_stream__static_method__Player);
     dummy_var ^= ((int64_t) (void*) wire_progress_state_stream__static_method__Player);
     dummy_var ^= ((int64_t) (void*) wire_callback_stream__static_method__Player);

--- a/rust/src/audio/controls.rs
+++ b/rust/src/audio/controls.rs
@@ -25,8 +25,8 @@ use crate::utils::types::ProgressState;
 
 lazy_static!
 {
-    /// Use this to communicate between the main thread and the decoder thread
-    /// Ex: play/pause commands
+    /// Use this to communicate between the main thread and the decoder thread.
+    /// Ex: play/pause commands.
     pub static ref TXRX: RwLock<(Sender<ThreadMessage>, Receiver<ThreadMessage>)> = RwLock::new(unbounded());
 
     /// Use this to communicate from the decoder to the main thread.
@@ -42,6 +42,17 @@ pub static IS_NORMALIZING: AtomicBool = AtomicBool::new(false);
 pub static VOLUME: RwLock<f32> = RwLock::new(1.0);
 pub static SEEK_TS: RwLock<Option<u64>> = RwLock::new(None);
 pub static PROGRESS: RwLock<ProgressState> = RwLock::new(ProgressState { position: 0, duration: 0 });
+
+pub fn reset_controls_to_default()
+{
+    IS_PLAYING.store(false, std::sync::atomic::Ordering::SeqCst);
+    IS_STOPPED.store(true, std::sync::atomic::Ordering::SeqCst);
+    IS_LOOPING.store(false, std::sync::atomic::Ordering::SeqCst);
+    IS_NORMALIZING.store(false, std::sync::atomic::Ordering::SeqCst);
+    *VOLUME.write().unwrap() = 1.0;
+    *SEEK_TS.write().unwrap() = None;
+    *PROGRESS.write().unwrap() = ProgressState { position: 0, duration: 0 };
+}
 
 pub enum ThreadMessage
 {

--- a/rust/src/bridge_generated.io.rs
+++ b/rust/src/bridge_generated.io.rs
@@ -12,6 +12,11 @@ pub extern "C" fn wire_new__static_method__Player(
 }
 
 #[no_mangle]
+pub extern "C" fn wire_dispose__static_method__Player(port_: i64) {
+    wire_dispose__static_method__Player_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_playback_state_stream__static_method__Player(port_: i64) {
     wire_playback_state_stream__static_method__Player_impl(port_)
 }

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -47,6 +47,16 @@ fn wire_new__static_method__Player_impl(
         },
     )
 }
+fn wire_dispose__static_method__Player_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "dispose__static_method__Player",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| Ok(Player::dispose()),
+    )
+}
 fn wire_playback_state_stream__static_method__Player_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -83,11 +83,13 @@ impl Player
     /// static variables in `controls.rs`.
     pub fn dispose()
     {
-        // Stop working the working thread.
+        // Stop the working thread.
         Self::signal_to_stop();
         // Reset the controls in `controls.rs` to default values.
         reset_controls_to_default();
         audio::streaming::streamable::IS_STREAM_BUFFERING.store(false, std::sync::atomic::Ordering::SeqCst);
+        // Reset the Linux/Windows media controllers.
+        metadata::dispose();
     }
 
     fn signal_to_stop()

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -79,6 +79,17 @@ impl Player
         Player { }
     }
 
+    /// Stops any old players/threads and resets the
+    /// static variables in `controls.rs`.
+    pub fn dispose()
+    {
+        // Stop working the working thread.
+        Self::signal_to_stop();
+        // Reset the controls in `controls.rs` to default values.
+        reset_controls_to_default();
+        audio::streaming::streamable::IS_STREAM_BUFFERING.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+
     fn signal_to_stop()
     {
         // If there are any threads in existence that were spawned when calling open(),
@@ -88,7 +99,7 @@ impl Player
 
         // Wait for the decoder thread to stop before proceeding.
         if let Some(txrx) = &*TXRX2.read().unwrap()
-        { let _ = txrx.1.recv(); }
+        { let _ = txrx.1.recv_timeout(std::time::Duration::from_millis(100)); }
 
         // Create new TXRXs to clear the messages.
         let mut txrx = TXRX.write().unwrap();
@@ -121,7 +132,7 @@ impl Player
     {
         let path2 = path.clone();
 
-        let source:Box<dyn MediaSource> = if path.contains("http") {
+        let source: Box<dyn MediaSource> = if path.contains("http") {
             if path.contains("m3u") {
                 Box::new(HlsStream::new(path)
                     .context(format!("Could not open HLS stream at \"{path2}\""))?

--- a/rust/src/metadata/mod.rs
+++ b/rust/src/metadata/mod.rs
@@ -60,10 +60,10 @@ pub fn dispose()
 
     #[cfg(target_os = "windows")]
     {
-        let smtc = smtc::HANDLER.read().unwrap();
-        if smtc.is_none() { return; }
-        // TODO
-        *smtc = None;
+        let mut lock = smtc::HANDLER.write().unwrap();
+        if lock.is_none() { return; }
+        let smtc = (*lock).take().unwrap();
+        smtc.stop();
     }
 }
 

--- a/rust/src/metadata/mod.rs
+++ b/rust/src/metadata/mod.rs
@@ -47,6 +47,25 @@ where
     }
 }
 
+/// Stops the OS's media controller.
+pub fn dispose()
+{
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios")))]
+    {
+        let mut lock = mpris::HANDLER.write().unwrap();
+        if lock.is_none() { return; }
+        let mpris = (*lock).take().unwrap();
+        mpris.stop();
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let smtc = smtc::HANDLER.read().unwrap();
+        if smtc.is_none() { return; }
+        // TODO
+        *smtc = None;
+    }
+}
 
 pub fn set_metadata(metadata: Metadata)
 {

--- a/rust/src/metadata/mpris.rs
+++ b/rust/src/metadata/mpris.rs
@@ -28,11 +28,11 @@ use crate::{utils::types::PlaybackState, audio::controls::PROGRESS};
 
 use super::types::{Metadata, Event, Command, Actions};
 
-pub static HANDLER:RwLock<Option<Mpris>> = RwLock::new(None);
+pub static HANDLER: RwLock<Option<Mpris>> = RwLock::new(None);
 
 pub struct Mpris
 {
-    tx:crossbeam::channel::Sender<Command>
+    tx: crossbeam::channel::Sender<Command>
 }
 
 impl Mpris

--- a/rust/src/metadata/types.rs
+++ b/rust/src/metadata/types.rs
@@ -48,7 +48,8 @@ pub enum Event
 pub enum Command
 {
     SetMetadata(Metadata),
-    SetPlaybackState(PlaybackState)
+    SetPlaybackState(PlaybackState),
+    Stop
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
Fixes #9

Currently, `simple_audio` doesn't do anything about a hot restart. This can cause some issues (ex. an old player is still playing). This PR will fix such issues and allow `simple_audio` to function as expected.