### PR TITLE
Decoder Rework

### DIFF
--- a/rust/src/audio/controls.rs
+++ b/rust/src/audio/controls.rs
@@ -29,11 +29,6 @@ lazy_static!
     /// Use this to communicate between the main thread and the decoder thread.
     /// Ex: play/pause commands.
     pub static ref TXRX: RwLock<(Sender<ThreadMessage>, Receiver<ThreadMessage>)> = RwLock::new(unbounded());
-
-    /// Use this to communicate from the decoder to the main thread.
-    /// Ex: Tell the main thread this thread is done.
-    // This is an option because we don't want to wait for a non existent thread on the first run.
-    pub static ref TXRX2: RwLock<Option<(Sender<bool>, Receiver<bool>)>> = RwLock::new(None);
 }
 
 pub static IS_PLAYING: AtomicBool = AtomicBool::new(false);
@@ -57,11 +52,13 @@ pub fn reset_controls_to_default()
 
 pub enum ThreadMessage
 {
+    /// Stops the current running thread.
+    Dispose,
     Open(Box<dyn MediaSource>),
     Play,
     Pause,
     Stop,
     /// Called by `cpal_output` in the event the device outputting
     /// audio was changed/disconnected.
-    DeviceChanged
+    DeviceChanged,
 }

--- a/rust/src/audio/controls.rs
+++ b/rust/src/audio/controls.rs
@@ -20,6 +20,7 @@ use std::sync::{RwLock, atomic::AtomicBool};
 
 use crossbeam::channel::{Sender, Receiver, unbounded};
 use lazy_static::lazy_static;
+use symphonia::core::io::MediaSource;
 
 use crate::utils::types::ProgressState;
 
@@ -56,6 +57,7 @@ pub fn reset_controls_to_default()
 
 pub enum ThreadMessage
 {
+    Open(Box<dyn MediaSource>),
     Play,
     Pause,
     Stop,

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -192,7 +192,7 @@ impl CpalOutput
         }
 
         while let Some(written) = self.ring_buffer_writer.write(samples) {
-            samples = &samples[written..]
+            samples = &samples[written..];
         }
     }
 

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -27,7 +27,7 @@ pub struct Decoder
 {
     rx: Receiver<ThreadMessage>,
     cpal_output: Option<CpalOutput>,
-    playback_config: Option<PlaybackConfig>
+    playback: Option<Playback>
 }
 
 impl Decoder
@@ -40,28 +40,27 @@ impl Decoder
         Decoder {
             rx,
             cpal_output: None,
-            playback_config: None
+            playback: None
         }
     }
 
     /// Starts decoding in an infinite loop.
-    /// 
     /// Listens for any incoming `ThreadMessage`s.
+    /// 
+    /// If playing, then the decoder decodes packets
+    /// until the file is done playing.
+    /// 
+    /// If stopped, the decoder goes into an idle state
+    /// where it waits for a message to come.
     pub fn start(&mut self)
     {
         let mut state = DecoderState::Idle;
 
         loop
         {
-            // Poll the status of the RX in lib.rs.
             // If the player is paused, then block this thread until a message comes in
             // to save the CPU.
-            let recv: Option<ThreadMessage> = if state.is_waiting()
-                // This will always be None on the first iteration
-                // which is good because we don't need to block
-                // on the first iteration.
-                && self.cpal_output.is_some()
-            {
+            let recv: Option<ThreadMessage> = if state.is_idle() || state.is_paused() {
                 self.rx.recv().ok()
             } else {
                 self.rx.try_recv().ok()
@@ -74,26 +73,12 @@ impl Decoder
                 Some(message) => match message
                 {
                     ThreadMessage::Open(source) => {
-                        if let Ok(result) = self.open(source) {
-                            let track = result.default_track()
-                                .context("Cannot start playback. There are no tracks present in the file.").unwrap();
-                            let track_id = track.id;
+                        if let Ok(playback) = self.open(source) {
+                            let mut lock = PROGRESS.write().unwrap();
+                            *lock = ProgressState { position: 0, duration: playback.duration };
+                            drop(lock);
 
-                            let decoder = default::get_codecs().make(&track.codec_params, &Default::default())
-                                .unwrap();
-
-                            // Used only for outputting the current position and duration.
-                            let timebase = track.codec_params.time_base.unwrap();
-                            let ts = track.codec_params.n_frames.map(|frames| track.codec_params.start_ts + frames).unwrap();
-                            let duration = timebase.calc_time(ts).seconds;
-
-                            self.playback_config = Some(PlaybackConfig {
-                                reader: result,
-                                decoder,
-                                track_id,
-                                timebase,
-                                duration,
-                            });
+                            self.playback = Some(playback);
                         }
                     },
                     ThreadMessage::Play => {
@@ -118,7 +103,7 @@ impl Decoder
                     }
                     ThreadMessage::Stop => {
                         self.cpal_output = None;
-                        self.playback_config = None;
+                        self.playback = None;
                         state = DecoderState::Idle;
                     },
                     // When the device is changed/disconnected,
@@ -128,20 +113,16 @@ impl Decoder
                     // playback themselves.
                     ThreadMessage::DeviceChanged => {
                         self.cpal_output = None;
-                        // This method sends a `ThreadMessage::Pause` but it is
-                        // ignored because `cpal_output` is `None`.
                         crate::Player::internal_pause();
                     },
                 }
             }
 
-            if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
-            { continue; }
+            if state.is_paused() { continue; }
 
             let result = self.do_playback();
 
             // The playback has finished.
-            // TODO: Handle stop and finish playback.
             if result.is_err() {
                 self.finish_playback();
                 state = DecoderState::Idle;
@@ -149,14 +130,15 @@ impl Decoder
         }
     }
 
+    /// Decodes a packet and writes to `cpal_output`.
     fn do_playback(&mut self) -> anyhow::Result<()>
     {
-        if let Some(playback_config) = self.playback_config.as_mut()
+        if let Some(playback) = self.playback.as_mut()
         {
             let seek_ts: u64 = if let Some(seek_ts) = *SEEK_TS.read().unwrap()
             {
-                let seek_to = SeekTo::Time { time: Time::from(seek_ts), track_id: Some(playback_config.track_id) };
-                match playback_config.reader.seek(SeekMode::Coarse, seek_to)
+                let seek_to = SeekTo::Time { time: Time::from(seek_ts), track_id: Some(playback.track_id) };
+                match playback.reader.seek(SeekMode::Coarse, seek_to)
                 {
                     Ok(seeked_to) => seeked_to.required_ts,
                     Err(_) => 0
@@ -167,7 +149,7 @@ impl Decoder
             if SEEK_TS.read().unwrap().is_some()
             {
                 *SEEK_TS.write().unwrap() = None;
-                playback_config.decoder.reset();
+                playback.decoder.reset();
                 // Clear the ring buffer which prevents the writer
                 // from blocking.
                 if let Some(cpal_output) = self.cpal_output.as_ref()
@@ -176,7 +158,7 @@ impl Decoder
             }
 
             // Decode the next packet.
-            let packet = match playback_config.reader.next_packet()
+            let packet = match playback.reader.next_packet()
             {
                 Ok(packet) => packet,
                 // An error occurs when the stream
@@ -193,17 +175,17 @@ impl Decoder
                 }
             };
 
-            if packet.track_id() != playback_config.track_id { return Ok(()); }
+            if packet.track_id() != playback.track_id { return Ok(()); }
 
-            let decoded = playback_config.decoder.decode(&packet)
+            let decoded = playback.decoder.decode(&packet)
                 .context("Could not decode audio packet.")?;
 
             if packet.ts() < seek_ts { return Ok(()); }
                 
             // Update the progress stream with calculated times.
             let progress = ProgressState {
-                position: playback_config.timebase.calc_time(packet.ts()).seconds,
-                duration: playback_config.duration
+                position: playback.timebase.calc_time(packet.ts()).seconds,
+                duration: playback.duration
             };
 
             update_progress_state_stream(progress);
@@ -223,17 +205,11 @@ impl Decoder
         Ok(())
     }
 
+    /// Called when the file is finished playing.
+    /// 
+    /// Flushes `cpal_output` and sends a `Done` message to Dart.
     fn finish_playback(&mut self)
     {
-        // Tell the main thread that everything is done here.
-        // tx.send(true).unwrap();
-
-        // This code is only ran if the stream
-        // reached the end of the audio.
-        // if !has_reached_end { return Ok(()); }
-        
-        // Flushing isn't needed when the user deliberately
-        // stops the stream because they no longer care about the remaining samples.
         if let Some(cpal_output) = self.cpal_output.as_mut()
         { cpal_output.flush(); }
 
@@ -247,7 +223,9 @@ impl Decoder
         crate::metadata::set_playback_state(PlaybackState::Done);
     }
 
-    fn open(&self, source: Box<dyn MediaSource>) -> anyhow::Result<Box<dyn FormatReader>>
+    /// Opens the given source for playback. Returns a `Playback`
+    /// for the source.
+    fn open(&mut self, source: Box<dyn MediaSource>) -> anyhow::Result<Playback>
     {
         let mss = MediaSourceStream::new(source, Default::default());
         let format_options = FormatOptions { enable_gapless: true, ..Default::default() };
@@ -260,195 +238,28 @@ impl Decoder
             &metadata_options
         ).context("Failed to create format reader.")?;
 
-        Ok(probed.format)
+        let reader = probed.format;
+
+        let track = reader.default_track()
+            .context("Cannot start playback. There are no tracks present in the file.").unwrap();
+        let track_id = track.id;
+
+        let decoder = default::get_codecs().make(&track.codec_params, &Default::default())
+            .unwrap();
+
+        // Used only for outputting the current position and duration.
+        let timebase = track.codec_params.time_base.unwrap();
+        let ts = track.codec_params.n_frames.map(|frames| track.codec_params.start_ts + frames).unwrap();
+        let duration = timebase.calc_time(ts).seconds;
+
+        Ok(Playback {
+            reader,
+            decoder,
+            track_id,
+            timebase,
+            duration,
+        })
     }
-
-    // pub fn decode_(&mut self, source: Box<dyn MediaSource>) -> anyhow::Result<()>
-    // {
-    //     let mss = MediaSourceStream::new(source, Default::default());
-
-    //     let format_options = FormatOptions { enable_gapless: true, ..Default::default() };
-    //     let metadata_options: MetadataOptions = Default::default();
-
-    //     let mut probed = default::get_probe().format(
-    //         &Hint::new(),
-    //         mss,
-    //         &format_options,
-    //         &metadata_options
-    //     ).context("Failed to create decoder.")?;
-
-    //     self.decode_loop_(&mut probed.format)?;
-
-    //     Ok(())
-    // }
-
-    // fn decode_loop_(&mut self, reader: &mut Box<dyn FormatReader>) -> anyhow::Result<()>
-    // {
-    //     let track = reader.default_track()
-    //         .context("Cannot start playback. There are no tracks present in the file.")?;
-    //     let track_id = track.id;
-
-    //     let mut decoder = default::get_codecs().make(&track.codec_params, &Default::default())?;
-    //     let mut cpal_output: Option<CpalOutput> = None;
-
-    //     // Used only for outputting the current position and duration.
-    //     let timebase = track.codec_params.time_base.unwrap();
-    //     let ts = track.codec_params.n_frames.map(|frames| track.codec_params.start_ts + frames).unwrap();
-    //     let duration = timebase.calc_time(ts).seconds;
-
-    //     let mut lock = PROGRESS.write().unwrap();
-    //     *lock = ProgressState { position: 0, duration };
-    //     drop(lock);
-
-    //     // Clone a receiver to listen for the stop signal.
-    //     let rx = TXRX.read().unwrap().1.clone();
-
-    //     let lock = TXRX2.read().unwrap();
-    //     let tx = lock.as_ref().unwrap().0.clone();
-    //     drop(lock);
-
-    //     let mut has_reached_end = false;
-
-    //     loop
-    //     {
-    //         // Poll the status of the RX in lib.rs.
-    //         // If the player is paused, then block this thread until a message comes in
-    //         // to save the CPU.
-    //         let recv: Option<ThreadMessage> = if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
-    //             // This will always be None on the first iteration
-    //             // which is good because we don't need to block
-    //             // on the first iteration.
-    //             && cpal_output.is_some()
-    //         {
-    //             rx.recv().ok()
-    //         } else {
-    //             rx.try_recv().ok()
-    //         };
-
-    //         match recv
-    //         {
-    //             None => (),
-    //             Some(message) => match message
-    //             {
-    //                 ThreadMessage::Play if cfg!(not(target_os = "windows")) => {
-    //                     if let Some(cpal_output) = cpal_output.as_ref()
-    //                     { cpal_output.stream.play()?; }
-    //                 },
-    //                 ThreadMessage::Pause if cfg!(not(target_os = "windows")) => {
-    //                     if let Some(cpal_output) = cpal_output.as_ref()
-    //                     { cpal_output.stream.pause()?; }
-    //                 },
-    //                 ThreadMessage::Stop => break,
-    //                 // When the device is changed/disconnected,
-    //                 // then we should reestablish a connection.
-    //                 // To make a new connection, dispose of the current cpal_output
-    //                 // and pause playback. Once the user is ready, they can start
-    //                 // playback themselves.
-    //                 ThreadMessage::DeviceChanged => {
-    //                     cpal_output = None;
-    //                     // This method sends a `ThreadMessage::Pause` but it is
-    //                     // ignored because `cpal_output` is `None`.
-    //                     crate::Player::internal_pause();
-    //                 }
-    //                 _ => ()
-    //             }
-    //         }
-
-    //         if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
-    //         { continue; }
-
-    //         // Seeking.
-    //         let seek_ts: u64 = if let Some(seek_ts) = *SEEK_TS.read().unwrap()
-    //         {
-    //             let seek_to = SeekTo::Time { time: Time::from(seek_ts), track_id: Some(track_id) };
-    //             match reader.seek(SeekMode::Coarse, seek_to)
-    //             {
-    //                 Ok(seeked_to) => seeked_to.required_ts,
-    //                 Err(_) => 0
-    //             }
-    //         } else { 0 };
-
-    //         // Clean up seek stuff.
-    //         if SEEK_TS.read().unwrap().is_some()
-    //         {
-    //             *SEEK_TS.write().unwrap() = None;
-    //             decoder.reset();
-    //             // Clear the ring buffer which prevents the writer
-    //             // from blocking.
-    //             if let Some(cpal_output) = cpal_output.as_ref()
-    //             { cpal_output.ring_buffer_reader.skip_all(); }
-    //             continue;
-    //         }
-
-    //         // Decode the next packet.
-    //         let packet = match reader.next_packet()
-    //         {
-    //             Ok(packet) => packet,
-    //             // An error occurs when the stream
-    //             // has reached the end of the audio.
-    //             Err(_) => {
-    //                 if IS_LOOPING.load(std::sync::atomic::Ordering::SeqCst)
-    //                 {
-    //                     *SEEK_TS.write().unwrap() = Some(0);
-    //                     crate::utils::callback_stream::update_callback_stream(Callback::PlaybackLooped);
-    //                     continue;
-    //                 }
-
-    //                 has_reached_end = true;
-    //                 break;
-    //             }
-    //         };
-
-    //         if packet.track_id() != track_id { continue; }
-
-    //         let decoded = decoder.decode(&packet)
-    //             .context("Could not decode audio packet.")?;
-
-    //         if packet.ts() < seek_ts { continue; }
-                
-    //         // Update the progress stream with calculated times.
-    //         let progress = ProgressState {
-    //             position: timebase.calc_time(packet.ts()).seconds,
-    //             duration
-    //         };
-
-    //         update_progress_state_stream(progress);
-    //         *PROGRESS.write().unwrap() = progress;
-
-    //         // Write the decoded packet to CPAL.
-    //         if cpal_output.is_none()
-    //         {
-    //             let spec = *decoded.spec();
-    //             let duration = decoded.capacity() as u64;
-    //             cpal_output.replace(CpalOutput::new(spec, duration)?);
-    //         }
-
-    //         cpal_output.as_mut().unwrap().write(decoded);
-    //     }
-
-    //     // Tell the main thread that everything is done here.
-    //     tx.send(true).unwrap();
-
-    //     // This code is only ran if the stream
-    //     // reached the end of the audio.
-    //     if !has_reached_end { return Ok(()); }
-        
-    //     // Flushing isn't needed when the user deliberately
-    //     // stops the stream because they no longer care about the remaining samples.
-    //     if let Some(cpal_output) = cpal_output.as_mut()
-    //     { cpal_output.flush(); }
-
-    //     // Send the done message once cpal finishes flushing.
-    //     // There may be samples left over and we don't want to
-    //     // start playing another file before they are read.
-    //     update_playback_state_stream(PlaybackState::Done);
-    //     update_progress_state_stream(ProgressState { position: 0, duration: 0 });
-    //     *PROGRESS.write().unwrap() = ProgressState { position: 0, duration: 0 };
-    //     IS_PLAYING.store(false, std::sync::atomic::Ordering::SeqCst);
-    //     crate::metadata::set_playback_state(PlaybackState::Done);
-
-    //     Ok(())
-    // }
 }
 
 enum DecoderState
@@ -460,8 +271,16 @@ enum DecoderState
 
 impl DecoderState
 {
-    fn is_waiting(&self) -> bool {
+    fn is_idle(&self) -> bool {
         if let DecoderState::Idle = self {
+            return true;
+        }
+
+        false
+    }
+
+    fn is_paused(&self) -> bool {
+        if let DecoderState::Paused = self {
             return true;
         }
 
@@ -469,7 +288,10 @@ impl DecoderState
     }
 }
 
-struct PlaybackConfig {
+/// Holds the items related to playback.
+/// 
+/// Ex: The Symphonia decoder, timebase, duration.
+struct Playback {
     reader: Box<dyn FormatReader>,
     track_id: u32,
     decoder: Box<dyn symphonia::core::codecs::Decoder>,

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -14,118 +14,149 @@
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <https://www.gnu.org/licenses/>.
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use cpal::traits::StreamTrait;
-use symphonia::{core::{formats::{FormatOptions, FormatReader, SeekTo, SeekMode}, meta::MetadataOptions, io::{MediaSourceStream, MediaSource}, probe::Hint, units::Time}, default};
+use crossbeam::channel::Receiver;
+use symphonia::{core::{formats::{FormatOptions, FormatReader, SeekTo, SeekMode}, meta::MetadataOptions, io::{MediaSourceStream, MediaSource}, probe::Hint, units::{Time, TimeBase}}, default};
 
 use crate::utils::{progress_state_stream::*, playback_state_stream::update_playback_state_stream, types::*};
 
 use super::{cpal_output::CpalOutput, controls::*};
 
-#[derive(Default)]
-pub struct Decoder;
+pub struct Decoder
+{
+    rx: Receiver<ThreadMessage>,
+    cpal_output: Option<CpalOutput>,
+    playback_config: Option<PlaybackConfig>
+}
 
 impl Decoder
 {
-    pub fn decode(&mut self, source: Box<dyn MediaSource>) -> anyhow::Result<()>
+    /// Creates a new decoder.
+    pub fn new() -> Self
     {
-        let mss = MediaSourceStream::new(source, Default::default());
-
-        let format_options = FormatOptions { enable_gapless: true, ..Default::default() };
-        let metadata_options: MetadataOptions = Default::default();
-
-        let mut probed = default::get_probe().format(
-            &Hint::new(),
-            mss,
-            &format_options,
-            &metadata_options
-        ).context("Failed to create decoder.")?;
-
-        self.decode_loop(&mut probed.format)?;
-
-        Ok(())
-    }
-
-    fn decode_loop(&mut self, reader: &mut Box<dyn FormatReader>) -> anyhow::Result<()>
-    {
-        let track = reader.default_track()
-            .context("Cannot start playback. There are no tracks present in the file.")?;
-        let track_id = track.id;
-
-        let mut decoder = default::get_codecs().make(&track.codec_params, &Default::default())?;
-        let mut cpal_output: Option<CpalOutput> = None;
-
-        // Used only for outputting the current position and duration.
-        let timebase = track.codec_params.time_base.unwrap();
-        let ts = track.codec_params.n_frames.map(|frames| track.codec_params.start_ts + frames).unwrap();
-        let duration = timebase.calc_time(ts).seconds;
-
-        let mut lock = PROGRESS.write().unwrap();
-        *lock = ProgressState { position: 0, duration };
-        drop(lock);
-
-        // Clone a receiver to listen for the stop signal.
         let rx = TXRX.read().unwrap().1.clone();
 
-        let lock = TXRX2.read().unwrap();
-        let tx = lock.as_ref().unwrap().0.clone();
-        drop(lock);
+        Decoder {
+            rx,
+            cpal_output: None,
+            playback_config: None
+        }
+    }
 
-        let mut has_reached_end = false;
+    /// Starts decoding in an infinite loop.
+    /// 
+    /// Listens for any incoming `ThreadMessage`s.
+    pub fn start(&mut self)
+    {
+        let mut state = DecoderState::Idle;
 
         loop
         {
             // Poll the status of the RX in lib.rs.
             // If the player is paused, then block this thread until a message comes in
             // to save the CPU.
-            let recv: Option<ThreadMessage> = if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
+            let recv: Option<ThreadMessage> = if state.is_waiting()
                 // This will always be None on the first iteration
                 // which is good because we don't need to block
                 // on the first iteration.
-                && cpal_output.is_some()
+                && self.cpal_output.is_some()
             {
-                rx.recv().ok()
+                self.rx.recv().ok()
             } else {
-                rx.try_recv().ok()
+                self.rx.try_recv().ok()
             };
 
+            // TODO: Error handling for the thread messages.
             match recv
             {
                 None => (),
                 Some(message) => match message
                 {
-                    ThreadMessage::Play if cfg!(not(target_os = "windows")) => {
-                        if let Some(cpal_output) = cpal_output.as_ref()
-                        { cpal_output.stream.play()?; }
+                    ThreadMessage::Open(source) => {
+                        if let Ok(result) = self.open(source) {
+                            let track = result.default_track()
+                                .context("Cannot start playback. There are no tracks present in the file.").unwrap();
+                            let track_id = track.id;
+
+                            let decoder = default::get_codecs().make(&track.codec_params, &Default::default())
+                                .unwrap();
+
+                            // Used only for outputting the current position and duration.
+                            let timebase = track.codec_params.time_base.unwrap();
+                            let ts = track.codec_params.n_frames.map(|frames| track.codec_params.start_ts + frames).unwrap();
+                            let duration = timebase.calc_time(ts).seconds;
+
+                            self.playback_config = Some(PlaybackConfig {
+                                reader: result,
+                                decoder,
+                                track_id,
+                                timebase,
+                                duration,
+                            });
+                        }
                     },
-                    ThreadMessage::Pause if cfg!(not(target_os = "windows")) => {
-                        if let Some(cpal_output) = cpal_output.as_ref()
-                        { cpal_output.stream.pause()?; }
+                    ThreadMessage::Play => {
+                        state = DecoderState::Playing;
+
+                        // Windows handles play/pause differently.
+                        if cfg!(not(target_os = "windows")) {
+                            if let Some(cpal_output) = &self.cpal_output {
+                                let _ = cpal_output.stream.play();
+                            }
+                        }
                     },
-                    ThreadMessage::Stop => break,
+                    ThreadMessage::Pause => {
+                        state = DecoderState::Paused;
+
+                        // Windows handles play/pause differently.
+                        if cfg!(not(target_os = "windows")) {
+                            if let Some(cpal_output) = &self.cpal_output {
+                                let _ = cpal_output.stream.pause();
+                            }
+                        }
+                    }
+                    ThreadMessage::Stop => {
+                        self.cpal_output = None;
+                        self.playback_config = None;
+                        state = DecoderState::Idle;
+                    },
                     // When the device is changed/disconnected,
                     // then we should reestablish a connection.
                     // To make a new connection, dispose of the current cpal_output
                     // and pause playback. Once the user is ready, they can start
                     // playback themselves.
                     ThreadMessage::DeviceChanged => {
-                        cpal_output = None;
+                        self.cpal_output = None;
                         // This method sends a `ThreadMessage::Pause` but it is
                         // ignored because `cpal_output` is `None`.
                         crate::Player::internal_pause();
-                    }
-                    _ => ()
+                    },
                 }
             }
 
             if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
             { continue; }
 
-            // Seeking.
+            let result = self.do_playback();
+
+            // The playback has finished.
+            // TODO: Handle stop and finish playback.
+            if result.is_err() {
+                self.finish_playback();
+                state = DecoderState::Idle;
+            }
+        }
+    }
+
+    fn do_playback(&mut self) -> anyhow::Result<()>
+    {
+        if let Some(playback_config) = self.playback_config.as_mut()
+        {
             let seek_ts: u64 = if let Some(seek_ts) = *SEEK_TS.read().unwrap()
             {
-                let seek_to = SeekTo::Time { time: Time::from(seek_ts), track_id: Some(track_id) };
-                match reader.seek(SeekMode::Coarse, seek_to)
+                let seek_to = SeekTo::Time { time: Time::from(seek_ts), track_id: Some(playback_config.track_id) };
+                match playback_config.reader.seek(SeekMode::Coarse, seek_to)
                 {
                     Ok(seeked_to) => seeked_to.required_ts,
                     Err(_) => 0
@@ -136,16 +167,16 @@ impl Decoder
             if SEEK_TS.read().unwrap().is_some()
             {
                 *SEEK_TS.write().unwrap() = None;
-                decoder.reset();
+                playback_config.decoder.reset();
                 // Clear the ring buffer which prevents the writer
                 // from blocking.
-                if let Some(cpal_output) = cpal_output.as_ref()
+                if let Some(cpal_output) = self.cpal_output.as_ref()
                 { cpal_output.ring_buffer_reader.skip_all(); }
-                continue;
+                return Ok(());
             }
 
             // Decode the next packet.
-            let packet = match reader.next_packet()
+            let packet = match playback_config.reader.next_packet()
             {
                 Ok(packet) => packet,
                 // An error occurs when the stream
@@ -155,51 +186,55 @@ impl Decoder
                     {
                         *SEEK_TS.write().unwrap() = Some(0);
                         crate::utils::callback_stream::update_callback_stream(Callback::PlaybackLooped);
-                        continue;
+                        return Ok(());
                     }
 
-                    has_reached_end = true;
-                    break;
+                    return Err(anyhow!("Finished playback."));
                 }
             };
 
-            if packet.track_id() != track_id { continue; }
+            if packet.track_id() != playback_config.track_id { return Ok(()); }
 
-            let decoded = decoder.decode(&packet)
+            let decoded = playback_config.decoder.decode(&packet)
                 .context("Could not decode audio packet.")?;
 
-            if packet.ts() < seek_ts { continue; }
+            if packet.ts() < seek_ts { return Ok(()); }
                 
             // Update the progress stream with calculated times.
             let progress = ProgressState {
-                position: timebase.calc_time(packet.ts()).seconds,
-                duration
+                position: playback_config.timebase.calc_time(packet.ts()).seconds,
+                duration: playback_config.duration
             };
 
             update_progress_state_stream(progress);
             *PROGRESS.write().unwrap() = progress;
 
             // Write the decoded packet to CPAL.
-            if cpal_output.is_none()
+            if self.cpal_output.is_none()
             {
                 let spec = *decoded.spec();
                 let duration = decoded.capacity() as u64;
-                cpal_output.replace(CpalOutput::new(spec, duration)?);
+                self.cpal_output.replace(CpalOutput::new(spec, duration)?);
             }
 
-            cpal_output.as_mut().unwrap().write(decoded);
+            self.cpal_output.as_mut().unwrap().write(decoded);
         }
 
+        Ok(())
+    }
+
+    fn finish_playback(&mut self)
+    {
         // Tell the main thread that everything is done here.
-        tx.send(true).unwrap();
+        // tx.send(true).unwrap();
 
         // This code is only ran if the stream
         // reached the end of the audio.
-        if !has_reached_end { return Ok(()); }
+        // if !has_reached_end { return Ok(()); }
         
         // Flushing isn't needed when the user deliberately
         // stops the stream because they no longer care about the remaining samples.
-        if let Some(cpal_output) = cpal_output.as_mut()
+        if let Some(cpal_output) = self.cpal_output.as_mut()
         { cpal_output.flush(); }
 
         // Send the done message once cpal finishes flushing.
@@ -210,7 +245,234 @@ impl Decoder
         *PROGRESS.write().unwrap() = ProgressState { position: 0, duration: 0 };
         IS_PLAYING.store(false, std::sync::atomic::Ordering::SeqCst);
         crate::metadata::set_playback_state(PlaybackState::Done);
-
-        Ok(())
     }
+
+    fn open(&self, source: Box<dyn MediaSource>) -> anyhow::Result<Box<dyn FormatReader>>
+    {
+        let mss = MediaSourceStream::new(source, Default::default());
+        let format_options = FormatOptions { enable_gapless: true, ..Default::default() };
+        let metadata_options: MetadataOptions = Default::default();
+
+        let probed = default::get_probe().format(
+            &Hint::new(),
+            mss,
+            &format_options,
+            &metadata_options
+        ).context("Failed to create format reader.")?;
+
+        Ok(probed.format)
+    }
+
+    // pub fn decode_(&mut self, source: Box<dyn MediaSource>) -> anyhow::Result<()>
+    // {
+    //     let mss = MediaSourceStream::new(source, Default::default());
+
+    //     let format_options = FormatOptions { enable_gapless: true, ..Default::default() };
+    //     let metadata_options: MetadataOptions = Default::default();
+
+    //     let mut probed = default::get_probe().format(
+    //         &Hint::new(),
+    //         mss,
+    //         &format_options,
+    //         &metadata_options
+    //     ).context("Failed to create decoder.")?;
+
+    //     self.decode_loop_(&mut probed.format)?;
+
+    //     Ok(())
+    // }
+
+    // fn decode_loop_(&mut self, reader: &mut Box<dyn FormatReader>) -> anyhow::Result<()>
+    // {
+    //     let track = reader.default_track()
+    //         .context("Cannot start playback. There are no tracks present in the file.")?;
+    //     let track_id = track.id;
+
+    //     let mut decoder = default::get_codecs().make(&track.codec_params, &Default::default())?;
+    //     let mut cpal_output: Option<CpalOutput> = None;
+
+    //     // Used only for outputting the current position and duration.
+    //     let timebase = track.codec_params.time_base.unwrap();
+    //     let ts = track.codec_params.n_frames.map(|frames| track.codec_params.start_ts + frames).unwrap();
+    //     let duration = timebase.calc_time(ts).seconds;
+
+    //     let mut lock = PROGRESS.write().unwrap();
+    //     *lock = ProgressState { position: 0, duration };
+    //     drop(lock);
+
+    //     // Clone a receiver to listen for the stop signal.
+    //     let rx = TXRX.read().unwrap().1.clone();
+
+    //     let lock = TXRX2.read().unwrap();
+    //     let tx = lock.as_ref().unwrap().0.clone();
+    //     drop(lock);
+
+    //     let mut has_reached_end = false;
+
+    //     loop
+    //     {
+    //         // Poll the status of the RX in lib.rs.
+    //         // If the player is paused, then block this thread until a message comes in
+    //         // to save the CPU.
+    //         let recv: Option<ThreadMessage> = if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
+    //             // This will always be None on the first iteration
+    //             // which is good because we don't need to block
+    //             // on the first iteration.
+    //             && cpal_output.is_some()
+    //         {
+    //             rx.recv().ok()
+    //         } else {
+    //             rx.try_recv().ok()
+    //         };
+
+    //         match recv
+    //         {
+    //             None => (),
+    //             Some(message) => match message
+    //             {
+    //                 ThreadMessage::Play if cfg!(not(target_os = "windows")) => {
+    //                     if let Some(cpal_output) = cpal_output.as_ref()
+    //                     { cpal_output.stream.play()?; }
+    //                 },
+    //                 ThreadMessage::Pause if cfg!(not(target_os = "windows")) => {
+    //                     if let Some(cpal_output) = cpal_output.as_ref()
+    //                     { cpal_output.stream.pause()?; }
+    //                 },
+    //                 ThreadMessage::Stop => break,
+    //                 // When the device is changed/disconnected,
+    //                 // then we should reestablish a connection.
+    //                 // To make a new connection, dispose of the current cpal_output
+    //                 // and pause playback. Once the user is ready, they can start
+    //                 // playback themselves.
+    //                 ThreadMessage::DeviceChanged => {
+    //                     cpal_output = None;
+    //                     // This method sends a `ThreadMessage::Pause` but it is
+    //                     // ignored because `cpal_output` is `None`.
+    //                     crate::Player::internal_pause();
+    //                 }
+    //                 _ => ()
+    //             }
+    //         }
+
+    //         if !IS_PLAYING.load(std::sync::atomic::Ordering::SeqCst)
+    //         { continue; }
+
+    //         // Seeking.
+    //         let seek_ts: u64 = if let Some(seek_ts) = *SEEK_TS.read().unwrap()
+    //         {
+    //             let seek_to = SeekTo::Time { time: Time::from(seek_ts), track_id: Some(track_id) };
+    //             match reader.seek(SeekMode::Coarse, seek_to)
+    //             {
+    //                 Ok(seeked_to) => seeked_to.required_ts,
+    //                 Err(_) => 0
+    //             }
+    //         } else { 0 };
+
+    //         // Clean up seek stuff.
+    //         if SEEK_TS.read().unwrap().is_some()
+    //         {
+    //             *SEEK_TS.write().unwrap() = None;
+    //             decoder.reset();
+    //             // Clear the ring buffer which prevents the writer
+    //             // from blocking.
+    //             if let Some(cpal_output) = cpal_output.as_ref()
+    //             { cpal_output.ring_buffer_reader.skip_all(); }
+    //             continue;
+    //         }
+
+    //         // Decode the next packet.
+    //         let packet = match reader.next_packet()
+    //         {
+    //             Ok(packet) => packet,
+    //             // An error occurs when the stream
+    //             // has reached the end of the audio.
+    //             Err(_) => {
+    //                 if IS_LOOPING.load(std::sync::atomic::Ordering::SeqCst)
+    //                 {
+    //                     *SEEK_TS.write().unwrap() = Some(0);
+    //                     crate::utils::callback_stream::update_callback_stream(Callback::PlaybackLooped);
+    //                     continue;
+    //                 }
+
+    //                 has_reached_end = true;
+    //                 break;
+    //             }
+    //         };
+
+    //         if packet.track_id() != track_id { continue; }
+
+    //         let decoded = decoder.decode(&packet)
+    //             .context("Could not decode audio packet.")?;
+
+    //         if packet.ts() < seek_ts { continue; }
+                
+    //         // Update the progress stream with calculated times.
+    //         let progress = ProgressState {
+    //             position: timebase.calc_time(packet.ts()).seconds,
+    //             duration
+    //         };
+
+    //         update_progress_state_stream(progress);
+    //         *PROGRESS.write().unwrap() = progress;
+
+    //         // Write the decoded packet to CPAL.
+    //         if cpal_output.is_none()
+    //         {
+    //             let spec = *decoded.spec();
+    //             let duration = decoded.capacity() as u64;
+    //             cpal_output.replace(CpalOutput::new(spec, duration)?);
+    //         }
+
+    //         cpal_output.as_mut().unwrap().write(decoded);
+    //     }
+
+    //     // Tell the main thread that everything is done here.
+    //     tx.send(true).unwrap();
+
+    //     // This code is only ran if the stream
+    //     // reached the end of the audio.
+    //     if !has_reached_end { return Ok(()); }
+        
+    //     // Flushing isn't needed when the user deliberately
+    //     // stops the stream because they no longer care about the remaining samples.
+    //     if let Some(cpal_output) = cpal_output.as_mut()
+    //     { cpal_output.flush(); }
+
+    //     // Send the done message once cpal finishes flushing.
+    //     // There may be samples left over and we don't want to
+    //     // start playing another file before they are read.
+    //     update_playback_state_stream(PlaybackState::Done);
+    //     update_progress_state_stream(ProgressState { position: 0, duration: 0 });
+    //     *PROGRESS.write().unwrap() = ProgressState { position: 0, duration: 0 };
+    //     IS_PLAYING.store(false, std::sync::atomic::Ordering::SeqCst);
+    //     crate::metadata::set_playback_state(PlaybackState::Done);
+
+    //     Ok(())
+    // }
+}
+
+enum DecoderState
+{
+    Playing,
+    Paused,
+    Idle
+}
+
+impl DecoderState
+{
+    fn is_waiting(&self) -> bool {
+        if let DecoderState::Idle = self {
+            return true;
+        }
+
+        false
+    }
+}
+
+struct PlaybackConfig {
+    reader: Box<dyn FormatReader>,
+    track_id: u32,
+    decoder: Box<dyn symphonia::core::codecs::Decoder>,
+    timebase: TimeBase,
+    duration: u64
 }

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -175,8 +175,9 @@ impl Decoder
             playback.decoder.reset();
             // Clear the ring buffer which prevents the writer
             // from blocking.
-            if let Some(cpal_output) = self.cpal_output.as_ref()
-            { cpal_output.ring_buffer_reader.skip_all(); }
+            if let Some(cpal_output) = self.cpal_output.as_ref() {
+                cpal_output.ring_buffer_reader.skip_all();
+            }
             return Ok(false);
         }
 
@@ -232,8 +233,9 @@ impl Decoder
     /// Flushes `cpal_output` and sends a `Done` message to Dart.
     fn finish_playback(&mut self)
     {
-        if let Some(cpal_output) = self.cpal_output.as_mut()
-        { cpal_output.flush(); }
+        if let Some(cpal_output) = self.cpal_output.as_mut() {
+            cpal_output.flush();
+        }
 
         // Send the done message once cpal finishes flushing.
         // There may be samples left over and we don't want to
@@ -263,12 +265,11 @@ impl Decoder
         let reader = probed.format;
 
         let track = reader.default_track()
-            .context("Cannot start playback. There are no tracks present in the file.").unwrap();
+            .context("Cannot start playback. There are no tracks present in the file.")?;
         let track_id = track.id;
 
         let decoder = default::get_codecs()
-            .make(&track.codec_params, &Default::default())
-            .unwrap();
+            .make(&track.codec_params, &Default::default())?;
 
         // Used only for outputting the current position and duration.
         let timebase = track.codec_params.time_base.unwrap();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -81,12 +81,8 @@ impl Player
 
         // Start the decoding thread.
         thread::spawn(|| {
-            let mut decoder = Decoder::new();
+            let decoder = Decoder::new();
             decoder.start();
-
-            // if result.is_err() {
-            //     update_callback_stream(Callback::DecodeError);
-            // }
         });
 
         Player { }
@@ -192,6 +188,7 @@ impl Player
         if IS_STOPPED.load(std::sync::atomic::Ordering::SeqCst) { return; }
 
         TXRX.read().unwrap().0.send(ThreadMessage::Stop).unwrap();
+
         update_progress_state_stream(ProgressState { position: 0, duration: 0 });
         update_playback_state_stream(PlaybackState::Pause);
         *PROGRESS.write().unwrap() = ProgressState { position: 0, duration: 0 };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -141,6 +141,7 @@ impl Player
             )
         };
 
+        IS_STOPPED.store(false, std::sync::atomic::Ordering::SeqCst);
         TXRX.read().unwrap().0.send(ThreadMessage::Open(source))?;
 
         if autoplay { Self::internal_play(); }
@@ -160,7 +161,6 @@ impl Player
 
         update_playback_state_stream(PlaybackState::Play);
         IS_PLAYING.store(true, std::sync::atomic::Ordering::SeqCst);
-        IS_STOPPED.store(false, std::sync::atomic::Ordering::SeqCst);
         crate::metadata::set_playback_state(PlaybackState::Play);
     }
     
@@ -175,7 +175,6 @@ impl Player
 
         update_playback_state_stream(PlaybackState::Pause);
         IS_PLAYING.store(false, std::sync::atomic::Ordering::SeqCst);
-        IS_STOPPED.store(false, std::sync::atomic::Ordering::SeqCst);
         crate::metadata::set_playback_state(PlaybackState::Pause);
     }
 


### PR DESCRIPTION
This PR changes the decoder behavior.

Currently, each time `open()` is called, a new thread is spawned. In this thread, a decoder is created and starts a loop.

The reason I decided to rework the decoder is because the method above causes issues related to multiple playbacks happening at once. For example, if you spam `open()`, there will be 2 threads decoding and outputting audio. This is not desired.

Instead of having a decoder for each time `open()` is called, there is a single decoder and thread (spawned when creating a new player). The only time this thread will close is when the player is disposed. With this method, it is easy to ensure only 1 playback is happening. The user can now call `open()` in quick succession and have only 1 playback.

This PR also makes the decoder code easier to read/understand by splitting things up into their own methods with comments.