### PR TITLE
Remove global/static controls

### DIFF
--- a/ios/Classes/bridge_generated.h
+++ b/ios/Classes/bridge_generated.h
@@ -21,8 +21,12 @@ typedef struct wire_uint_8_list {
   int32_t len;
 } wire_uint_8_list;
 
-typedef struct wire_Player {
+typedef struct wire_Controls {
+  const void *ptr;
+} wire_Controls;
 
+typedef struct wire_Player {
+  struct wire_Controls controls;
 } wire_Player;
 
 typedef struct wire_Metadata {
@@ -95,6 +99,8 @@ void wire_normalize_volume__method__Player(int64_t port_,
                                            struct wire_Player *that,
                                            bool should_normalize);
 
+struct wire_Controls new_Controls(void);
+
 int64_t *new_box_autoadd_i64_0(int64_t value);
 
 struct wire_Metadata *new_box_autoadd_metadata_0(void);
@@ -104,6 +110,10 @@ struct wire_Player *new_box_autoadd_player_0(void);
 struct wire_list_media_control_action *new_list_media_control_action_0(int32_t len);
 
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
+
+void drop_opaque_Controls(const void *ptr);
+
+const void *share_opaque_Controls(const void *ptr);
 
 void free_WireSyncReturn(WireSyncReturn ptr);
 
@@ -128,11 +138,14 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_seek__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_set_metadata__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_normalize_volume__method__Player);
+    dummy_var ^= ((int64_t) (void*) new_Controls);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_i64_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_metadata_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_player_0);
     dummy_var ^= ((int64_t) (void*) new_list_media_control_action_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
+    dummy_var ^= ((int64_t) (void*) drop_opaque_Controls);
+    dummy_var ^= ((int64_t) (void*) share_opaque_Controls);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturn);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     dummy_var ^= ((int64_t) (void*) get_dart_object);

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -110,6 +110,24 @@ abstract class SimpleAudio {
       {required Player that, required bool shouldNormalize, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kNormalizeVolumeMethodPlayerConstMeta;
+
+  DropFnType get dropOpaqueControls;
+  ShareFnType get shareOpaqueControls;
+  OpaqueTypeFinalizer get ControlsFinalizer;
+}
+
+@sealed
+class Controls extends FrbOpaque {
+  final SimpleAudio bridge;
+  Controls.fromRaw(int ptr, int size, this.bridge) : super.unsafe(ptr, size);
+  @override
+  DropFnType get dropFn => bridge.dropOpaqueControls;
+
+  @override
+  ShareFnType get shareFn => bridge.shareOpaqueControls;
+
+  @override
+  OpaqueTypeFinalizer get staticFinalizer => bridge.ControlsFinalizer;
 }
 
 /// Events that are handled in Dart because they
@@ -195,9 +213,11 @@ enum PlaybackState {
 
 class Player {
   final SimpleAudio bridge;
+  final Controls controls;
 
   const Player({
     required this.bridge,
+    required this.controls,
   });
 
   static Future<Player> newPlayer(

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -16,8 +16,9 @@ abstract class SimpleAudio {
 
   FlutterRustBridgeTaskConstMeta get kNewStaticMethodPlayerConstMeta;
 
-  /// Stops any old players/threads and resets the
-  /// static variables in `controls.rs`.
+  /// Stop media controllers and reset `IS_STREAM_BUFFERING`.
+  ///
+  /// The decoder thread is automatically disposed as the controls are dropped.
   Future<void> disposeStaticMethodPlayer({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kDisposeStaticMethodPlayerConstMeta;
@@ -229,8 +230,9 @@ class Player {
       bridge.newStaticMethodPlayer(
           actions: actions, dbusName: dbusName, hwnd: hwnd, hint: hint);
 
-  /// Stops any old players/threads and resets the
-  /// static variables in `controls.rs`.
+  /// Stop media controllers and reset `IS_STREAM_BUFFERING`.
+  ///
+  /// The decoder thread is automatically disposed as the controls are dropped.
   static Future<void> dispose({required SimpleAudio bridge, dynamic hint}) =>
       bridge.disposeStaticMethodPlayer(hint: hint);
 

--- a/lib/src/bridge_generated.dart
+++ b/lib/src/bridge_generated.dart
@@ -390,10 +390,18 @@ class SimpleAudioImpl implements SimpleAudio {
         argNames: ["that", "shouldNormalize"],
       );
 
+  DropFnType get dropOpaqueControls => _platform.inner.drop_opaque_Controls;
+  ShareFnType get shareOpaqueControls => _platform.inner.share_opaque_Controls;
+  OpaqueTypeFinalizer get ControlsFinalizer => _platform.ControlsFinalizer;
+
   void dispose() {
     _platform.dispose();
   }
 // Section: wire2api
+
+  Controls _wire2api_Controls(dynamic raw) {
+    return Controls.fromRaw(raw[0], raw[1], this);
+  }
 
   bool _wire2api_bool(dynamic raw) {
     return raw as bool;
@@ -413,10 +421,11 @@ class SimpleAudioImpl implements SimpleAudio {
 
   Player _wire2api_player(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 0)
-      throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return Player(
       bridge: this,
+      controls: _wire2api_Controls(arr[0]),
     );
   }
 
@@ -474,6 +483,13 @@ class SimpleAudioPlatform extends FlutterRustBridgeBase<SimpleAudioWire> {
 // Section: api2wire
 
   @protected
+  wire_Controls api2wire_Controls(Controls raw) {
+    final ptr = inner.new_Controls();
+    _api_fill_to_wire_Controls(raw, ptr);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_uint_8_list> api2wire_String(String raw) {
     return api2wire_uint_8_list(utf8.encoder.convert(raw));
   }
@@ -493,6 +509,7 @@ class SimpleAudioPlatform extends FlutterRustBridgeBase<SimpleAudioWire> {
   @protected
   ffi.Pointer<wire_Player> api2wire_box_autoadd_player(Player raw) {
     final ptr = inner.new_box_autoadd_player_0();
+    _api_fill_to_wire_player(raw, ptr.ref);
     return ptr;
   }
 
@@ -539,11 +556,23 @@ class SimpleAudioPlatform extends FlutterRustBridgeBase<SimpleAudioWire> {
   }
 // Section: finalizer
 
+  late final OpaqueTypeFinalizer _ControlsFinalizer =
+      OpaqueTypeFinalizer(inner._drop_opaque_ControlsPtr);
+  OpaqueTypeFinalizer get ControlsFinalizer => _ControlsFinalizer;
 // Section: api_fill_to_wire
+
+  void _api_fill_to_wire_Controls(Controls apiObj, wire_Controls wireObj) {
+    wireObj.ptr = apiObj.shareOrMove();
+  }
 
   void _api_fill_to_wire_box_autoadd_metadata(
       Metadata apiObj, ffi.Pointer<wire_Metadata> wireObj) {
     _api_fill_to_wire_metadata(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_autoadd_player(
+      Player apiObj, ffi.Pointer<wire_Player> wireObj) {
+    _api_fill_to_wire_player(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_metadata(Metadata apiObj, wire_Metadata wireObj) {
@@ -554,7 +583,9 @@ class SimpleAudioPlatform extends FlutterRustBridgeBase<SimpleAudioWire> {
     wireObj.art_bytes = api2wire_opt_uint_8_list(apiObj.artBytes);
   }
 
-  void _api_fill_to_wire_player(Player apiObj, wire_Player wireObj) {}
+  void _api_fill_to_wire_player(Player apiObj, wire_Player wireObj) {
+    wireObj.controls = api2wire_Controls(apiObj.controls);
+  }
 }
 
 // ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names
@@ -1008,6 +1039,15 @@ class SimpleAudioWire implements FlutterRustBridgeWireBase {
       _wire_normalize_volume__method__PlayerPtr
           .asFunction<void Function(int, ffi.Pointer<wire_Player>, bool)>();
 
+  wire_Controls new_Controls() {
+    return _new_Controls();
+  }
+
+  late final _new_ControlsPtr =
+      _lookup<ffi.NativeFunction<wire_Controls Function()>>('new_Controls');
+  late final _new_Controls =
+      _new_ControlsPtr.asFunction<wire_Controls Function()>();
+
   ffi.Pointer<ffi.Int64> new_box_autoadd_i64_0(
     int value,
   ) {
@@ -1073,6 +1113,35 @@ class SimpleAudioWire implements FlutterRustBridgeWireBase {
   late final _new_uint_8_list_0 = _new_uint_8_list_0Ptr
       .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
+  void drop_opaque_Controls(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _drop_opaque_Controls(
+      ptr,
+    );
+  }
+
+  late final _drop_opaque_ControlsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'drop_opaque_Controls');
+  late final _drop_opaque_Controls = _drop_opaque_ControlsPtr
+      .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  ffi.Pointer<ffi.Void> share_opaque_Controls(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _share_opaque_Controls(
+      ptr,
+    );
+  }
+
+  late final _share_opaque_ControlsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Void> Function(
+              ffi.Pointer<ffi.Void>)>>('share_opaque_Controls');
+  late final _share_opaque_Controls = _share_opaque_ControlsPtr
+      .asFunction<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>();
+
   void free_WireSyncReturn(
     WireSyncReturn ptr,
   ) {
@@ -1104,7 +1173,13 @@ class wire_uint_8_list extends ffi.Struct {
   external int len;
 }
 
-class wire_Player extends ffi.Opaque {}
+class wire_Controls extends ffi.Struct {
+  external ffi.Pointer<ffi.Void> ptr;
+}
+
+class wire_Player extends ffi.Struct {
+  external wire_Controls controls;
+}
 
 class wire_Metadata extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> title;
@@ -1121,6 +1196,6 @@ class wire_Metadata extends ffi.Struct {
 typedef DartPostCObjectFnType = ffi.Pointer<
     ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;
-typedef uintptr_t = ffi.UnsignedLongLong;
+typedef uintptr_t = ffi.UnsignedLong;
 
 const int CHUNK_SIZE = 131072;

--- a/macos/Classes/bridge_generated.h
+++ b/macos/Classes/bridge_generated.h
@@ -21,8 +21,12 @@ typedef struct wire_uint_8_list {
   int32_t len;
 } wire_uint_8_list;
 
-typedef struct wire_Player {
+typedef struct wire_Controls {
+  const void *ptr;
+} wire_Controls;
 
+typedef struct wire_Player {
+  struct wire_Controls controls;
 } wire_Player;
 
 typedef struct wire_Metadata {
@@ -95,6 +99,8 @@ void wire_normalize_volume__method__Player(int64_t port_,
                                            struct wire_Player *that,
                                            bool should_normalize);
 
+struct wire_Controls new_Controls(void);
+
 int64_t *new_box_autoadd_i64_0(int64_t value);
 
 struct wire_Metadata *new_box_autoadd_metadata_0(void);
@@ -104,6 +110,10 @@ struct wire_Player *new_box_autoadd_player_0(void);
 struct wire_list_media_control_action *new_list_media_control_action_0(int32_t len);
 
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
+
+void drop_opaque_Controls(const void *ptr);
+
+const void *share_opaque_Controls(const void *ptr);
 
 void free_WireSyncReturn(WireSyncReturn ptr);
 
@@ -128,11 +138,14 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_seek__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_set_metadata__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_normalize_volume__method__Player);
+    dummy_var ^= ((int64_t) (void*) new_Controls);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_i64_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_metadata_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_player_0);
     dummy_var ^= ((int64_t) (void*) new_list_media_control_action_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
+    dummy_var ^= ((int64_t) (void*) drop_opaque_Controls);
+    dummy_var ^= ((int64_t) (void*) share_opaque_Controls);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturn);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     dummy_var ^= ((int64_t) (void*) get_dart_object);

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,6 @@ reqwest = { version = "0", features = ["blocking", "native-tls-vendored"] }
 symphonia = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements", features = ["all"] }
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 rubato = "0.12.0"
-lazy_static = "1.4.0"
 rangemap = "1.3.0"
 arrayvec = "0.7.2"
 ebur128 = "0.1.7"

--- a/rust/src/audio/controls.rs
+++ b/rust/src/audio/controls.rs
@@ -16,7 +16,7 @@
 
 // A file that defines controls globally.
 
-use std::sync::{atomic::AtomicBool, RwLock};
+use std::sync::{atomic::AtomicBool, Arc, RwLock};
 
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use lazy_static::lazy_static;
@@ -30,31 +30,37 @@ lazy_static! {
     pub static ref TXRX: RwLock<(Sender<ThreadMessage>, Receiver<ThreadMessage>)> = RwLock::new(unbounded());
 }
 
-pub static IS_PLAYING: AtomicBool = AtomicBool::new(false);
-pub static IS_STOPPED: AtomicBool = AtomicBool::new(true);
-pub static IS_LOOPING: AtomicBool = AtomicBool::new(false);
-pub static IS_NORMALIZING: AtomicBool = AtomicBool::new(false);
-pub static IS_FILE_PRELOADED: AtomicBool = AtomicBool::new(false);
-pub static VOLUME: RwLock<f32> = RwLock::new(1.0);
-pub static SEEK_TS: RwLock<Option<u64>> = RwLock::new(None);
-pub static PROGRESS: RwLock<ProgressState> = RwLock::new(ProgressState {
-    position: 0,
-    duration: 0,
-});
-
-pub fn reset_controls_to_default()
+#[derive(Clone)]
+pub struct Controls
 {
-    IS_PLAYING.store(false, std::sync::atomic::Ordering::SeqCst);
-    IS_STOPPED.store(true, std::sync::atomic::Ordering::SeqCst);
-    IS_LOOPING.store(false, std::sync::atomic::Ordering::SeqCst);
-    IS_NORMALIZING.store(false, std::sync::atomic::Ordering::SeqCst);
-    IS_FILE_PRELOADED.store(false, std::sync::atomic::Ordering::SeqCst);
-    *VOLUME.write().unwrap() = 1.0;
-    *SEEK_TS.write().unwrap() = None;
-    *PROGRESS.write().unwrap() = ProgressState {
-        position: 0,
-        duration: 0,
-    };
+    pub is_playing: Arc<AtomicBool>,
+    pub is_stopped: Arc<AtomicBool>,
+    pub is_looping: Arc<AtomicBool>,
+    pub is_normalizing: Arc<AtomicBool>,
+    pub is_file_preloaded: Arc<AtomicBool>,
+    pub volume: Arc<RwLock<f32>>,
+    pub seek_ts: Arc<RwLock<Option<u64>>>,
+    pub progress: Arc<RwLock<ProgressState>>,
+}
+
+impl Default for Controls
+{
+    fn default() -> Self
+    {
+        Controls {
+            is_playing: Arc::new(AtomicBool::new(false)),
+            is_stopped: Arc::new(AtomicBool::new(true)),
+            is_looping: Arc::new(AtomicBool::new(false)),
+            is_normalizing: Arc::new(AtomicBool::new(false)),
+            is_file_preloaded: Arc::new(AtomicBool::new(false)),
+            volume: Arc::new(RwLock::new(1.0)),
+            seek_ts: Arc::new(RwLock::new(None)),
+            progress: Arc::new(RwLock::new(ProgressState {
+                position: 0,
+                duration: 0,
+            })),
+        }
+    }
 }
 
 pub enum ThreadMessage

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -97,7 +97,9 @@ impl CpalOutput
                 // With only a return statement, the current sample still plays.
                 // CPAL states that `stream.pause()` may not work for all devices.
                 // `stream.pause()` is the ideal way to play/pause.
-                if (!stream_controls.is_playing.load(std::sync::atomic::Ordering::SeqCst)
+                if (!stream_controls
+                    .is_playing
+                    .load(std::sync::atomic::Ordering::SeqCst)
                     && cfg!(target_os = "windows"))
                     || buffering
                 {
@@ -211,7 +213,11 @@ impl CpalOutput
             self.sample_buffer.samples()
         };
 
-        if self.controls.is_normalizing.load(std::sync::atomic::Ordering::SeqCst) {
+        if self
+            .controls
+            .is_normalizing
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             samples = self.normalizer.normalize(samples);
         }
 

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -84,56 +84,64 @@ impl CpalOutput
         let sample_buffer = SampleBuffer::<f32>::new(duration, spec);
 
         let is_stream_done = Arc::new((Mutex::new(false), Condvar::new()));
-        let is_stream_done_clone = is_stream_done.clone();
 
-        let stream_controls = controls.clone();
         let stream = device.build_output_stream(
             &config,
-            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                let buffering = IS_STREAM_BUFFERING.load(std::sync::atomic::Ordering::SeqCst);
+            {
+                let controls = controls.clone();
+                let is_stream_done = is_stream_done.clone();
+                move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                    let buffering = IS_STREAM_BUFFERING.load(std::sync::atomic::Ordering::SeqCst);
 
-                // "Pause" the stream.
-                // What this really does is mute the stream.
-                // With only a return statement, the current sample still plays.
-                // CPAL states that `stream.pause()` may not work for all devices.
-                // `stream.pause()` is the ideal way to play/pause.
-                if (!stream_controls.is_playing() && cfg!(target_os = "windows")) || buffering {
-                    data.iter_mut().for_each(|s| *s = 0.0);
+                    // "Pause" the stream.
+                    // What this really does is mute the stream.
+                    // With only a return statement, the current sample still plays.
+                    // CPAL states that `stream.pause()` may not work for all devices.
+                    // `stream.pause()` is the ideal way to play/pause.
+                    if (!controls.is_playing() && cfg!(target_os = "windows")) || buffering {
+                        data.iter_mut().for_each(|s| *s = 0.0);
 
-                    if buffering {
-                        ring_buffer_reader.skip_all();
+                        if buffering {
+                            ring_buffer_reader.skip_all();
+                        }
+
+                        return;
                     }
 
-                    return;
+                    let written = ring_buffer_reader.read(data);
+
+                    // Notify that the stream was finished reading.
+                    if written.is_none() {
+                        let (mutex, cvar) = &*is_stream_done;
+                        *mutex.lock().unwrap() = true;
+                        cvar.notify_one();
+                        return;
+                    }
+
+                    // Set the volume.
+                    data[0..written.unwrap()]
+                        .iter_mut()
+                        .for_each(|s| *s *= BASE_VOLUME * *controls.volume());
                 }
-
-                let written = ring_buffer_reader.read(data);
-
-                // Notify that the stream was finished reading.
-                if written.is_none() {
-                    let (mutex, cvar) = &*is_stream_done_clone;
-                    *mutex.lock().unwrap() = true;
-                    cvar.notify_one();
-                    return;
-                }
-
-                // Set the volume.
-                data[0..written.unwrap()]
-                    .iter_mut()
-                    .for_each(|s| *s *= BASE_VOLUME * stream_controls.volume());
             },
-            move |err| {
-                match err {
-                    cpal::StreamError::DeviceNotAvailable => {
-                        // Tell the decoder that there is no longer a valid device.
-                        // The decoder will make a new `cpal_output`.
-                        let tx = TXRX.read().unwrap().0.clone();
-                        tx.send(ThreadMessage::DeviceChanged).unwrap();
-                        ring_buffer_writer.cancel_write();
-                    }
-                    cpal::StreamError::BackendSpecific { err } => {
-                        // This should never happen.
-                        panic!("Unknown error occurred during playback: {err}");
+            {
+                let controls = controls.clone();
+                move |err| {
+                    match err {
+                        cpal::StreamError::DeviceNotAvailable => {
+                            // Tell the decoder that there is no longer a valid device.
+                            // The decoder will make a new `cpal_output`.
+                            controls
+                                .event_handler()
+                                .0
+                                .send(ThreadMessage::DeviceChanged)
+                                .unwrap();
+                            ring_buffer_writer.cancel_write();
+                        }
+                        cpal::StreamError::BackendSpecific { err } => {
+                            // This should never happen.
+                            panic!("Unknown error occurred during playback: {err}");
+                        }
                     }
                 }
             },

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -97,12 +97,7 @@ impl CpalOutput
                 // With only a return statement, the current sample still plays.
                 // CPAL states that `stream.pause()` may not work for all devices.
                 // `stream.pause()` is the ideal way to play/pause.
-                if (!stream_controls
-                    .is_playing
-                    .load(std::sync::atomic::Ordering::SeqCst)
-                    && cfg!(target_os = "windows"))
-                    || buffering
-                {
+                if (!stream_controls.is_playing() && cfg!(target_os = "windows")) || buffering {
                     data.iter_mut().for_each(|s| *s = 0.0);
 
                     if buffering {
@@ -125,7 +120,7 @@ impl CpalOutput
                 // Set the volume.
                 data[0..written.unwrap()]
                     .iter_mut()
-                    .for_each(|s| *s *= BASE_VOLUME * *stream_controls.volume.read().unwrap());
+                    .for_each(|s| *s *= BASE_VOLUME * stream_controls.volume());
             },
             move |err| {
                 match err {
@@ -213,11 +208,7 @@ impl CpalOutput
             self.sample_buffer.samples()
         };
 
-        if self
-            .controls
-            .is_normalizing
-            .load(std::sync::atomic::Ordering::SeqCst)
-        {
+        if self.controls.is_normalizing() {
             samples = self.normalizer.normalize(samples);
         }
 

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -173,7 +173,9 @@ impl Decoder
                 }
                 ThreadMessage::Preload(source) => {
                     self.preload_playback = None;
-                    self.controls.is_file_preloaded.store(false, std::sync::atomic::Ordering::SeqCst);
+                    self.controls
+                        .is_file_preloaded
+                        .store(false, std::sync::atomic::Ordering::SeqCst);
                     let handle = self.preload(source);
                     self.preload_thread = Some(handle);
                 }
@@ -185,7 +187,9 @@ impl Decoder
                     let (playback, cpal_output) = self.preload_playback.take().unwrap();
                     self.playback = Some(playback);
                     self.cpal_output = Some(cpal_output);
-                    self.controls.is_file_preloaded.store(false, std::sync::atomic::Ordering::SeqCst);
+                    self.controls
+                        .is_file_preloaded
+                        .store(false, std::sync::atomic::Ordering::SeqCst);
 
                     crate::Player::internal_play(&self.controls);
                 }
@@ -215,7 +219,8 @@ impl Decoder
             if self.cpal_output.is_none() {
                 let spec = *preload.spec();
                 let duration = preload.capacity() as u64;
-                self.cpal_output.replace(CpalOutput::new(self.controls.clone(), spec, duration)?);
+                self.cpal_output
+                    .replace(CpalOutput::new(self.controls.clone(), spec, duration)?);
             }
 
             let buffer_ref = preload.as_audio_buffer_ref();
@@ -250,7 +255,11 @@ impl Decoder
             // An error occurs when the stream
             // has reached the end of the audio.
             Err(_) => {
-                if self.controls.is_looping.load(std::sync::atomic::Ordering::SeqCst) {
+                if self
+                    .controls
+                    .is_looping
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                {
                     *self.controls.seek_ts.write().unwrap() = Some(0);
                     crate::utils::callback_stream::update_callback_stream(Callback::PlaybackLooped);
                     return Ok(false);
@@ -295,7 +304,8 @@ impl Decoder
         if self.cpal_output.is_none() {
             let spec = *decoded.spec();
             let duration = decoded.capacity() as u64;
-            self.cpal_output.replace(CpalOutput::new(self.controls.clone(), spec, duration)?);
+            self.cpal_output
+                .replace(CpalOutput::new(self.controls.clone(), spec, duration)?);
         }
 
         self.cpal_output.as_mut().unwrap().write(decoded);
@@ -325,8 +335,12 @@ impl Decoder
         update_progress_state_stream(progress_state);
         *self.controls.progress.write().unwrap() = progress_state;
 
-        self.controls.is_playing.store(false, std::sync::atomic::Ordering::SeqCst);
-        self.controls.is_stopped.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.controls
+            .is_playing
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        self.controls
+            .is_stopped
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         crate::media_controllers::set_playback_state(PlaybackState::Done);
     }
 
@@ -384,7 +398,10 @@ impl Decoder
     /// Spawns a thread that decodes the first packet of the source.
     ///
     /// Returns a preloaded `Playback` and `CpalOutput` when complete.
-    fn preload(&self, source: Box<dyn MediaSource>) -> JoinHandle<anyhow::Result<(Playback, CpalOutput)>>
+    fn preload(
+        &self,
+        source: Box<dyn MediaSource>,
+    ) -> JoinHandle<anyhow::Result<(Playback, CpalOutput)>>
     {
         let controls = self.controls.clone();
         thread::spawn(move || {
@@ -423,7 +440,9 @@ impl Decoder
             .unwrap_or(Err(anyhow!("Could not join preload thread.")))?;
 
         self.preload_playback.replace((result.0, result.1));
-        self.controls.is_file_preloaded.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.controls
+            .is_file_preloaded
+            .store(true, std::sync::atomic::Ordering::SeqCst);
 
         Ok(())
     }

--- a/rust/src/bridge_generated.io.rs
+++ b/rust/src/bridge_generated.io.rs
@@ -125,6 +125,11 @@ pub extern "C" fn wire_normalize_volume__method__Player(
 // Section: allocate functions
 
 #[no_mangle]
+pub extern "C" fn new_Controls() -> wire_Controls {
+    wire_Controls::new_with_null_ptr()
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_i64_0(value: i64) -> *mut i64 {
     support::new_leak_box_ptr(value)
 }
@@ -159,8 +164,28 @@ pub extern "C" fn new_uint_8_list_0(len: i32) -> *mut wire_uint_8_list {
 
 // Section: related functions
 
+#[no_mangle]
+pub extern "C" fn drop_opaque_Controls(ptr: *const c_void) {
+    unsafe {
+        Arc::<Controls>::decrement_strong_count(ptr as _);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn share_opaque_Controls(ptr: *const c_void) -> *const c_void {
+    unsafe {
+        Arc::<Controls>::increment_strong_count(ptr as _);
+        ptr
+    }
+}
+
 // Section: impl Wire2Api
 
+impl Wire2Api<RustOpaque<Controls>> for wire_Controls {
+    fn wire2api(self) -> RustOpaque<Controls> {
+        unsafe { support::opaque_from_dart(self.ptr as _) }
+    }
+}
 impl Wire2Api<String> for *mut wire_uint_8_list {
     fn wire2api(self) -> String {
         let vec: Vec<u8> = self.wire2api();
@@ -210,7 +235,9 @@ impl Wire2Api<Metadata> for wire_Metadata {
 
 impl Wire2Api<Player> for wire_Player {
     fn wire2api(self) -> Player {
-        Player {}
+        Player {
+            controls: self.controls.wire2api(),
+        }
     }
 }
 
@@ -223,6 +250,12 @@ impl Wire2Api<Vec<u8>> for *mut wire_uint_8_list {
     }
 }
 // Section: wire structs
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_Controls {
+    ptr: *const core::ffi::c_void,
+}
 
 #[repr(C)]
 #[derive(Clone)]
@@ -243,7 +276,9 @@ pub struct wire_Metadata {
 
 #[repr(C)]
 #[derive(Clone)]
-pub struct wire_Player {}
+pub struct wire_Player {
+    controls: wire_Controls,
+}
 
 #[repr(C)]
 #[derive(Clone)]
@@ -261,6 +296,14 @@ pub trait NewWithNullPtr {
 impl<T> NewWithNullPtr for *mut T {
     fn new_with_null_ptr() -> Self {
         std::ptr::null_mut()
+    }
+}
+
+impl NewWithNullPtr for wire_Controls {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            ptr: core::ptr::null(),
+        }
     }
 }
 
@@ -284,7 +327,9 @@ impl Default for wire_Metadata {
 
 impl NewWithNullPtr for wire_Player {
     fn new_with_null_ptr() -> Self {
-        Self {}
+        Self {
+            controls: wire_Controls::new_with_null_ptr(),
+        }
     }
 }
 

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -418,7 +418,7 @@ impl support::IntoDart for PlaybackState {
 impl support::IntoDartExceptPrimitive for PlaybackState {}
 impl support::IntoDart for Player {
     fn into_dart(self) -> support::DartAbi {
-        Vec::<u8>::new().into_dart()
+        vec![self.controls.into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Player {}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -28,14 +28,15 @@ use audio::{
     sources::{hls::HlsStream, http::HttpStream, local::Local},
 };
 use crossbeam::channel::unbounded;
-use flutter_rust_bridge::{StreamSink, RustOpaque};
+use flutter_rust_bridge::{RustOpaque, StreamSink};
 use media_controllers::types::{Event, MediaControlAction, Metadata};
 use symphonia::core::io::MediaSource;
 use utils::types::*;
 
 use crate::utils::{callback_stream::*, playback_state_stream::*, progress_state_stream::*};
 
-pub struct Player {
+pub struct Player
+{
     controls: RustOpaque<Controls>,
 }
 
@@ -54,7 +55,10 @@ impl Player
                 Event::Pause => Self::internal_pause(&controls),
                 Event::Stop => Self::internal_stop(&controls),
                 Event::PlayPause => {
-                    if controls.is_playing.load(std::sync::atomic::Ordering::SeqCst) {
+                    if controls
+                        .is_playing
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                    {
                         Self::internal_pause(&controls);
                     }
                     else {
@@ -94,7 +98,7 @@ impl Player
         });
 
         Player {
-            controls: RustOpaque::new(player_controls)
+            controls: RustOpaque::new(player_controls),
         }
     }
 
@@ -130,13 +134,17 @@ impl Player
 
     pub fn is_playing(&self) -> bool
     {
-        self.controls.is_playing.load(std::sync::atomic::Ordering::SeqCst)
+        self.controls
+            .is_playing
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Returns `true` if there is a file preloaded for playback.
     pub fn has_preloaded(&self) -> bool
     {
-        self.controls.is_file_preloaded.load(std::sync::atomic::Ordering::SeqCst)
+        self.controls
+            .is_file_preloaded
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     pub fn get_progress(&self) -> ProgressState
@@ -220,15 +228,22 @@ impl Player
     /// the `IS_PLAYING` AtomicBool.
     fn internal_play(controls: &Controls)
     {
-        if controls.is_playing.load(std::sync::atomic::Ordering::SeqCst) {
+        if controls
+            .is_playing
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             return;
         }
 
         TXRX.read().unwrap().0.send(ThreadMessage::Play).unwrap();
 
         update_playback_state_stream(PlaybackState::Play);
-        controls.is_playing.store(true, std::sync::atomic::Ordering::SeqCst);
-        controls.is_stopped.store(false, std::sync::atomic::Ordering::SeqCst);
+        controls
+            .is_playing
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        controls
+            .is_stopped
+            .store(false, std::sync::atomic::Ordering::SeqCst);
         media_controllers::set_playback_state(PlaybackState::Play);
     }
 
@@ -237,15 +252,22 @@ impl Player
     /// the `IS_PLAYING` AtomicBool.
     fn internal_pause(controls: &Controls)
     {
-        if !controls.is_playing.load(std::sync::atomic::Ordering::SeqCst) {
+        if !controls
+            .is_playing
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             return;
         }
 
         TXRX.read().unwrap().0.send(ThreadMessage::Pause).unwrap();
 
         update_playback_state_stream(PlaybackState::Pause);
-        controls.is_playing.store(false, std::sync::atomic::Ordering::SeqCst);
-        controls.is_stopped.store(false, std::sync::atomic::Ordering::SeqCst);
+        controls
+            .is_playing
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        controls
+            .is_stopped
+            .store(false, std::sync::atomic::Ordering::SeqCst);
         media_controllers::set_playback_state(PlaybackState::Pause);
     }
 
@@ -255,7 +277,10 @@ impl Player
     /// This stops all threads that are streaming.
     fn internal_stop(controls: &Controls)
     {
-        if controls.is_stopped.load(std::sync::atomic::Ordering::SeqCst) {
+        if controls
+            .is_stopped
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             return;
         }
 
@@ -269,8 +294,12 @@ impl Player
         update_progress_state_stream(progress);
         *controls.progress.write().unwrap() = progress;
         update_playback_state_stream(PlaybackState::Pause);
-        controls.is_playing.store(false, std::sync::atomic::Ordering::SeqCst);
-        controls.is_stopped.store(true, std::sync::atomic::Ordering::SeqCst);
+        controls
+            .is_playing
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        controls
+            .is_stopped
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         media_controllers::set_playback_state(PlaybackState::Pause);
     }
 
@@ -304,7 +333,9 @@ impl Player
 
     pub fn loop_playback(&self, should_loop: bool)
     {
-        self.controls.is_looping.store(should_loop, std::sync::atomic::Ordering::SeqCst);
+        self.controls
+            .is_looping
+            .store(should_loop, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub fn set_volume(&self, volume: f32)
@@ -324,7 +355,9 @@ impl Player
 
     pub fn normalize_volume(&self, should_normalize: bool)
     {
-        self.controls.is_normalizing.store(should_normalize, std::sync::atomic::Ordering::SeqCst);
+        self.controls
+            .is_normalizing
+            .store(should_normalize, std::sync::atomic::Ordering::SeqCst);
     }
 }
 

--- a/rust/src/media_controllers/mpris.rs
+++ b/rust/src/media_controllers/mpris.rs
@@ -38,7 +38,7 @@ use zbus::{
     zvariant::{ObjectPath, Value},
 };
 
-use crate::{audio::controls::PROGRESS, utils::types::PlaybackState};
+use crate::utils::types::PlaybackState;
 
 use super::types::{Command, Event, MediaControlAction, MediaController, Metadata};
 
@@ -250,9 +250,10 @@ impl PlayerInterface
     #[dbus_interface(property)]
     fn position(&self) -> i64
     {
-        let position = PROGRESS.read().unwrap().position;
-        let in_micros = Duration::from_secs(position).as_micros();
-        in_micros.try_into().unwrap_or_default()
+        // let position = PROGRESS.read().unwrap().position;
+        // let in_micros = Duration::from_secs(position).as_micros();
+        // in_micros.try_into().unwrap_or_default()
+        0
     }
 
     #[dbus_interface(property)]

--- a/rust/src/media_controllers/mpris.rs
+++ b/rust/src/media_controllers/mpris.rs
@@ -133,15 +133,15 @@ impl Mpris
                     match message {
                         Command::SetMetadata(data) => {
                             player_iface.metadata = data;
-                            player_iface.metadata_changed(&context).await?;
+                            player_iface.metadata_changed(context).await?;
                         }
                         Command::SetDuration(duration) => {
                             player_iface.duration = duration;
-                            player_iface.metadata_changed(&context).await?;
+                            player_iface.metadata_changed(context).await?;
                         }
                         Command::SetPlaybackState(state) => {
                             player_iface.playback_state = state;
-                            player_iface.playback_status_changed(&context).await?;
+                            player_iface.playback_status_changed(context).await?;
                         }
                         Command::Stop => break,
                     }


### PR DESCRIPTION
`simple_audio` has been using global static variables to control the decoder and audio output between threads. Although this works, it's not a clean approach. Rust's constant naming convention (all caps) also makes it harder to work with.

This PR aims to remove those variables and instead use a struct to group all the controls together. This provides a few benefits:

1. No global variables
2. Less verbose code (getters/setters generated via macros)
3. More flexibility (easier to reset, anything that needs it has every related control)