### PR TITLE
Opus support

### DIFF
--- a/plugin_tool.py
+++ b/plugin_tool.py
@@ -266,9 +266,9 @@ def build(targets:list[str], openssl_path:str = None):
             os.system("cargo build --release --target aarch64-apple-ios --manifest-path ./rust/Cargo.toml")
 
             env_vars = f"OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/lib OPENSSL_INCLUDE_DIR={openssl_path} OPENSSL_NO_VENDOR=1 " if openssl_path is not None else ""
-            os.system(f"{env_vars} CMAKE_OSX_SYSROOT=$(xcrun --sdk iphonesimulator --show-sdk-path) cargo build --release --target aarch64-apple-ios-sim --manifest-path ./rust/Cargo.toml")
+            os.system(f"{env_vars} cargo build --release --target aarch64-apple-ios-sim --manifest-path ./rust/Cargo.toml")
 
-            os.system("cargo build --release --target x86_64-apple-ios --manifest-path ./rust/Cargo.toml")
+            os.system("CMAKE_OSX_SYSROOT=$(xcrun --sdk iphonesimulator --show-sdk-path) cargo build --release --target x86_64-apple-ios --manifest-path ./rust/Cargo.toml")
             os.system(f'lipo "./rust/target/aarch64-apple-ios-sim/release/lib{package_name}.a" "./rust/target/x86_64-apple-ios/release/lib{package_name}.a" -output "lib{package_name}.a" -create')
             os.system(f"xcodebuild -create-xcframework -library ./rust/target/aarch64-apple-ios/release/lib{package_name}.a -library ./lib{package_name}.a -output {package_name}.xcframework")
             os.remove(f"./lib{package_name}.a")

--- a/plugin_tool.py
+++ b/plugin_tool.py
@@ -266,7 +266,7 @@ def build(targets:list[str], openssl_path:str = None):
             os.system("cargo build --release --target aarch64-apple-ios --manifest-path ./rust/Cargo.toml")
 
             env_vars = f"OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/lib OPENSSL_INCLUDE_DIR={openssl_path} OPENSSL_NO_VENDOR=1 " if openssl_path is not None else ""
-            os.system(f"{env_vars}cargo build --release --target aarch64-apple-ios-sim --manifest-path ./rust/Cargo.toml")
+            os.system(f"{env_vars} CMAKE_OSX_SYSROOT=$(xcrun --sdk iphonesimulator --show-sdk-path) cargo build --release --target aarch64-apple-ios-sim --manifest-path ./rust/Cargo.toml")
 
             os.system("cargo build --release --target x86_64-apple-ios --manifest-path ./rust/Cargo.toml")
             os.system(f'lipo "./rust/target/aarch64-apple-ios-sim/release/lib{package_name}.a" "./rust/target/x86_64-apple-ios/release/lib{package_name}.a" -output "lib{package_name}.a" -create')

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,8 +14,8 @@ reqwest = { version = "0", features = [
 	"rustls-tls",
 ], default-features = false }
 # symphonia = { version = "0.5.2", features = ["all"] }
-symphonia = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements", features = ["all"] }
-symphonia-core = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements" }
+symphonia = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-opus-improvements", features = ["all"] }
+symphonia-core = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-opus-improvements" }
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 rubato = "0.12.0"
 rangemap = "1.3.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,3 +50,6 @@ features = [
 
 [profile.release]
 lto = true
+
+[patch.crates-io]
+audiopus_sys = { git = "https://github.com/ProjectAnni/audiopus_sys" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,9 +14,7 @@ reqwest = { version = "0", features = [
 	"rustls-tls",
 ], default-features = false }
 # symphonia = { version = "0.5.2", features = ["all"] }
-symphonia = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements", features = [
-	"all",
-] }
+symphonia = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements", features = ["all"] }
 symphonia-core = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements" }
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 rubato = "0.12.0"
@@ -25,7 +23,7 @@ arrayvec = "0.7.2"
 ebur128 = "0.1.7"
 anyhow = "1.0.69"
 lazy_static = "1.4.0"
-audiopus = "0.2.0"
+audiopus = "0.3.0-rc.0"
 
 # Linux Dependencies
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios")))'.dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,4 +52,4 @@ features = [
 lto = true
 
 [patch.crates-io]
-audiopus_sys = { git = "https://github.com/ProjectAnni/audiopus_sys" }
+audiopus_sys = { git = "https://github.com/erikas-taroza/audiopus_sys" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,12 +17,15 @@ reqwest = { version = "0", features = [
 symphonia = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements", features = [
 	"all",
 ] }
+symphonia-core = { git = "https://github.com/erikas-taroza/Symphonia", branch = "mp4-improvements" }
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 rubato = "0.12.0"
 rangemap = "1.3.0"
 arrayvec = "0.7.2"
 ebur128 = "0.1.7"
 anyhow = "1.0.69"
+lazy_static = "1.4.0"
+audiopus = "0.2.0"
 
 # Linux Dependencies
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios")))'.dependencies]

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -22,6 +22,7 @@ use std::{
 use anyhow::{anyhow, Context};
 use cpal::traits::StreamTrait;
 use crossbeam::channel::Receiver;
+use lazy_static::lazy_static;
 use symphonia::{
     core::{
         audio::{AsAudioBufferRef, AudioBuffer},
@@ -31,10 +32,12 @@ use symphonia::{
         probe::Hint,
         units::{Time, TimeBase},
     },
-    default,
+    default::{self, register_enabled_codecs},
 };
+use symphonia_core::codecs::CodecRegistry;
 
 use crate::{
+    audio::opus::OpusDecoder,
     media_controllers,
     utils::{
         callback_stream::update_callback_stream,
@@ -43,6 +46,15 @@ use crate::{
 };
 
 use super::{controls::*, cpal_output::CpalOutput};
+
+lazy_static! {
+    static ref CODEC_REGISTRY: CodecRegistry = {
+        let mut registry = CodecRegistry::new();
+        register_enabled_codecs(&mut registry);
+        registry.register_all::<OpusDecoder>();
+        registry
+    };
+}
 
 pub struct Decoder
 {
@@ -382,7 +394,7 @@ impl Decoder
             .context("Cannot start playback. There are no tracks present in the file.")?;
         let track_id = track.id;
 
-        let decoder = default::get_codecs().make(&track.codec_params, &Default::default())?;
+        let decoder = CODEC_REGISTRY.make(&track.codec_params, &Default::default())?;
 
         // Used only for outputting the current position and duration.
         let timebase = track.codec_params.time_base.or_else(|| {

--- a/rust/src/audio/mod.rs
+++ b/rust/src/audio/mod.rs
@@ -18,4 +18,5 @@ pub mod controls;
 mod cpal_output;
 pub mod decoder;
 mod dsp;
+mod opus;
 pub mod sources;

--- a/rust/src/audio/opus.rs
+++ b/rust/src/audio/opus.rs
@@ -33,11 +33,8 @@ const SAMPLE_RATE: SampleRate = SampleRate::Hz48000;
 
 const SAMPLE_RATE_RAW: usize = 48_000;
 
-/// Number of audio frames/packets to be sent per second.
-const AUDIO_FRAME_RATE: usize = 1000 / 20; // FIXME: this value might be incorrect. We need to parse it from opus TOC.
-
 /// This is equally the number of stereo (joint) samples in an audio frame.
-const MONO_FRAME_SIZE: usize = SAMPLE_RATE_RAW / AUDIO_FRAME_RATE;
+const MONO_FRAME_SIZE: usize = SAMPLE_RATE_RAW / 1000 * 60; // 60ms is the max frame size
 
 /// Number of individual samples in one complete frame of stereo audio.
 const STEREO_FRAME_SIZE: usize = 2 * MONO_FRAME_SIZE;

--- a/rust/src/audio/opus.rs
+++ b/rust/src/audio/opus.rs
@@ -1,0 +1,177 @@
+// Modified from https://github.com/serenity-rs/songbird/blob/next/src/input/codecs/opus.rs
+//
+// ISC License (ISC)
+//
+// Copyright (c) 2020, Songbird Contributors
+//
+// Permission to use, copy, modify, and/or distribute this software for any purpose
+// with or without fee is hereby granted, provided that the above copyright notice
+// and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+// THIS SOFTWARE.
+
+use audiopus::{
+    coder::{Decoder as AudiopusDecoder, GenericCtl},
+    Channels, Error as OpusError, ErrorCode, SampleRate,
+};
+use symphonia_core::{
+    audio::{AsAudioBufferRef, AudioBuffer, AudioBufferRef, Layout, Signal, SignalSpec},
+    codecs::{
+        CodecDescriptor, CodecParameters, Decoder, DecoderOptions, FinalizeResult, CODEC_TYPE_OPUS,
+    },
+    errors::{decode_error, Result as SymphResult},
+    formats::Packet,
+};
+
+/// Sample rate of audio to be sent to Discord.
+const SAMPLE_RATE: SampleRate = SampleRate::Hz48000;
+
+/// Sample rate of audio to be sent to Discord.
+const SAMPLE_RATE_RAW: usize = 48_000;
+
+/// Number of audio frames/packets to be sent per second.
+const AUDIO_FRAME_RATE: usize = 50;
+
+/// This is equally the number of stereo (joint) samples in an audio frame.
+const MONO_FRAME_SIZE: usize = SAMPLE_RATE_RAW / AUDIO_FRAME_RATE;
+
+/// Number of individual samples in one complete frame of stereo audio.
+const STEREO_FRAME_SIZE: usize = 2 * MONO_FRAME_SIZE;
+
+/// Opus decoder for symphonia, based on libopus v1.3 (via [`audiopus`]).
+pub struct OpusDecoder
+{
+    inner: AudiopusDecoder,
+    params: CodecParameters,
+    buf: AudioBuffer<f32>,
+    rawbuf: Vec<f32>,
+}
+
+/// # SAFETY
+/// The underlying Opus decoder (currently) requires only a `&self` parameter
+/// to decode given packets, which is likely a mistaken decision.
+///
+/// This struct makes stronger assumptions and only touches FFI decoder state with a
+/// `&mut self`, preventing data races via `&OpusDecoder` as required by `impl Sync`.
+/// No access to other internal state relies on unsafety or crosses FFI.
+unsafe impl Sync for OpusDecoder {}
+
+impl OpusDecoder
+{
+    fn decode_inner(&mut self, packet: &Packet) -> SymphResult<()>
+    {
+        let s_ct = loop {
+            let pkt: Option<&[u8]> = if packet.buf().is_empty() {
+                None
+            }
+            else if let Ok(checked_pkt) = packet.buf().try_into() {
+                Some(checked_pkt)
+            }
+            else {
+                return decode_error("Opus packet was too large (greater than i32::MAX bytes).");
+            };
+            let out_space = &mut self.rawbuf[..];
+
+            match self.inner.decode_float(pkt, out_space, false) {
+                Ok(v) => break v,
+                Err(OpusError::Opus(ErrorCode::BufferTooSmall)) => {
+                    // double the buffer size
+                    // correct behav would be to mirror the decoder logic in the udp_rx set.
+                    let new_size = (self.rawbuf.len() * 2).min(std::i32::MAX as usize);
+                    if new_size == self.rawbuf.len() {
+                        return decode_error("Opus frame too big: cannot expand opus frame decode buffer any further.");
+                    }
+
+                    self.rawbuf.resize(new_size, 0.0);
+                    self.buf = AudioBuffer::new(
+                        self.rawbuf.len() as u64 / 2,
+                        SignalSpec::new_with_layout(SAMPLE_RATE_RAW as u32, Layout::Stereo),
+                    );
+                }
+                Err(e) => {
+                    return decode_error("Opus decode error: see 'tracing' logs.");
+                }
+            }
+        };
+
+        self.buf.clear();
+        self.buf.render_reserved(Some(s_ct));
+
+        // Forcibly assuming stereo, for now.
+        for ch in 0..2 {
+            let iter = self.rawbuf.chunks_exact(2).map(|chunk| chunk[ch]);
+            for (tgt, src) in self.buf.chan_mut(ch).iter_mut().zip(iter) {
+                *tgt = src;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Decoder for OpusDecoder
+{
+    fn try_new(params: &CodecParameters, _options: &DecoderOptions) -> SymphResult<Self>
+    {
+        let inner = AudiopusDecoder::new(SAMPLE_RATE, Channels::Stereo).unwrap();
+
+        let mut params = params.clone();
+        params.with_sample_rate(SAMPLE_RATE_RAW as u32);
+
+        Ok(Self {
+            inner,
+            params,
+            buf: AudioBuffer::new(
+                MONO_FRAME_SIZE as u64,
+                SignalSpec::new_with_layout(SAMPLE_RATE_RAW as u32, Layout::Stereo),
+            ),
+            rawbuf: vec![0.0f32; STEREO_FRAME_SIZE],
+        })
+    }
+
+    fn supported_codecs() -> &'static [CodecDescriptor]
+    {
+        &[symphonia_core::support_codec!(
+            CODEC_TYPE_OPUS,
+            "opus",
+            "libopus (1.3+, audiopus)"
+        )]
+    }
+
+    fn codec_params(&self) -> &CodecParameters
+    {
+        &self.params
+    }
+
+    fn decode(&mut self, packet: &Packet) -> SymphResult<AudioBufferRef<'_>>
+    {
+        if let Err(e) = self.decode_inner(packet) {
+            self.buf.clear();
+            Err(e)
+        }
+        else {
+            Ok(self.buf.as_audio_buffer_ref())
+        }
+    }
+
+    fn reset(&mut self)
+    {
+        _ = self.inner.reset_state();
+    }
+
+    fn finalize(&mut self) -> FinalizeResult
+    {
+        FinalizeResult::default()
+    }
+
+    fn last_decoded(&self) -> AudioBufferRef
+    {
+        self.buf.as_audio_buffer_ref()
+    }
+}


### PR DESCRIPTION
Basic support for opus format. Fixes #5

## Tested platforms
- [x] Windows (Build seems working)
- [x] Linux
- [x] macOS
  - [x] Intel
  - [x] ~~Apple Silicon~~ (I do not have a device, but the build seems working)
- [x] Android
- [x] iOS
  - [ ] Simulator: Playback becomes weird after switching to background
  - [x] iPadOS 16.2: Working well

## (Un)Resolved issues

- [x] ~~OPUS files can not loop.~~ Fixed in https://github.com/pdeljanov/Symphonia/pull/208. Cherry-picking might be necessary.
- [x] ~~Environment variable should be added on macOS: `export LIBOPUS_NO_PKG=1`~~ Not reproduced in CI 
- [x] **[Fixed in audiopus 0.3.0-rc.0]** Cross compiling on macOS seems broken. The arch seems wrong. The following error was produced:<details><pre><code>  = note: ld: warning: ignoring file /var/folders/rb/bxhfpzl102x2_tnj9yk973rw0000gq/T/rustcVhPrtK/libaudiopus_sys-3f9b1667c941e75f.rlib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
          Undefined symbols for architecture arm64:
            "_opus_decode_float", referenced from:
                _$LT$simple_audio..audio..opus..OpusDecoder$u20$as$u20$symphonia_core..codecs..Decoder$GT$::decode::h0b5a71e4cb0afd1a in simple_audio.simple_audio.c5df7263-cgu.15.rcgu.o
            "_opus_decoder_create", referenced from:
                core::ops::function::FnOnce::call_once::hd8bb0ff6e4953e9d in simple_audio.simple_audio.c5df7263-cgu.15.rcgu.o
            "_opus_decoder_ctl", referenced from:
                _$LT$simple_audio..audio..opus..OpusDecoder$u20$as$u20$symphonia_core..codecs..Decoder$GT$::reset::h473ffcfa89b67ec5 in simple_audio.simple_audio.c5df7263-cgu.15.rcgu.o
            "_opus_decoder_destroy", referenced from:
                core::ptr::drop_in_place$LT$audiopus..coder..decoder..Decoder$GT$::h2640be91522c9c00 in simple_audio.simple_audio.c5df7263-cgu.15.rcgu.o
                core::ptr::drop_in_place$LT$simple_audio..audio..opus..OpusDecoder$GT$::hb00d61fad74862dd in simple_audio.simple_audio.c5df7263-cgu.15.rcgu.o
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
</code></pre></details>
- [x] ~~Build fails on `x86_64-apple-ios` with:~~ Fixed in https://github.com/Lakelezz/audiopus_sys/pull/13 <details><pre><code>  In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/usr/include/limits.h:64:
  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/usr/include/machine/limits.h:11:2: error: architecture not supported
  #error architecture not supported</code></pre></details>