### PR TITLE
Use `tar.gz` instead of `zip` for Windows/Linux/Android releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,19 +58,19 @@ jobs:
       # Downloading unzips the artifacts so they have to be rezipped.
       - name: Download Artifacts
         uses: actions/download-artifact@v2.1.1
-      - name: Zip Files
+      - name: Create Archives
         run: |
-          zip -j linux.zip linux/*
-          cd android && zip -r android.zip ./* && cd .. && mv android/android.zip .
-          zip -j windows.zip windows/*
+          tar -czvf linux.tar.gz linux/libsimple_audio.so
+          tar -C android -czvf android.tar.gz .
+          tar -czvf windows.tar.gz windows/simple_audio.dll
           zip -j macos.zip macos/*
           cd ios && zip -r ios.zip ./* && cd .. && mv ios/ios.zip .
       - name: Add to Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            linux.zip
-            android.zip
-            windows.zip
+            linux.tar.gz
+            android.tar.gz
+            windows.tar.gz
             macos.zip
             ios.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,9 @@ jobs:
         uses: actions/download-artifact@v2.1.1
       - name: Create Archives
         run: |
-          tar -czvf linux.tar.gz linux/libsimple_audio.so
+          tar -C linux -czvf linux.tar.gz .
           tar -C android -czvf android.tar.gz .
-          tar -czvf windows.tar.gz windows/simple_audio.dll
+          tar -C windows -czvf windows.tar.gz .
           zip -j macos.zip macos/*
           cd ios && zip -r ios.zip ./* && cd .. && mv ios/ios.zip .
       - name: Add to Release

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ libsimple_audio.a
 simple_audio.dll
 simple_audio.xcframework
 *.zip
+*.tar.gz
 
 # Miscellaneous
 *.class

--- a/.pubignore
+++ b/.pubignore
@@ -3,3 +3,4 @@ libsimple_audio.so
 libsimple_audio.a
 ios/Frameworks/simple_audio.xcframework
 *.zip
+*.tar.gz

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -3,12 +3,18 @@ cmake_minimum_required(VERSION 3.10)
 # Download the binaries from GitHub.
 set(Version "1.6.1")
 set(LibPath "${CMAKE_CURRENT_SOURCE_DIR}/src/main/jniLibs")
+set(ArchivePath "${CMAKE_CURRENT_SOURCE_DIR}/android.tar.gz")
 
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/android.zip")
+if(NOT EXISTS ${ArchivePath})
   file(DOWNLOAD
-    "https://github.com/erikas-taroza/simple_audio/releases/download/v${Version}/android.zip"
-    "${CMAKE_CURRENT_SOURCE_DIR}/android.zip"
+    "https://github.com/erikas-taroza/simple_audio/releases/download/v${Version}/android.tar.gz"
+    ${ArchivePath}
     TLS_VERIFY ON
+  )
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${ArchivePath} -C ${LibPath}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
   file(ARCHIVE_EXTRACT INPUT android.zip DESTINATION ${LibPath})

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -11,11 +11,11 @@ if(NOT EXISTS ${ArchivePath})
     ${ArchivePath}
     TLS_VERIFY ON
   )
+endif()
 
+if(NOT EXISTS "${LibPath}/arm64-v8a/libsimple_audio.so")
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${ArchivePath} -C ${LibPath}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E tar -xzf ${ArchivePath}
+    WORKING_DIRECTORY ${LibPath}
   )
-
-  file(ARCHIVE_EXTRACT INPUT android.zip DESTINATION ${LibPath})
 endif()

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -47,9 +47,11 @@ if(NOT EXISTS ${LibPath})
     ${LibPath}
     TLS_VERIFY ON
   )
+endif()
 
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libsimple_audio.so")
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${LibPath}
+    COMMAND ${CMAKE_COMMAND} -E tar -xzf linux.tar.gz
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -40,15 +40,18 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
 # Download the binary from GitHub.
 set(Version "1.6.1")
-set(LibPath "${CMAKE_CURRENT_SOURCE_DIR}/linux.zip")
+set(LibPath "${CMAKE_CURRENT_SOURCE_DIR}/linux.tar.gz")
 if(NOT EXISTS ${LibPath})
   file(DOWNLOAD
-    "https://github.com/erikas-taroza/simple_audio/releases/download/v${Version}/linux.zip"
+    "https://github.com/erikas-taroza/simple_audio/releases/download/v${Version}/linux.tar.gz"
     ${LibPath}
     TLS_VERIFY ON
   )
 
-  file(ARCHIVE_EXTRACT INPUT ${LibPath} DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${LibPath}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 endif()
 
 # List of absolute paths to libraries that should be bundled with the plugin.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -46,15 +46,18 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
 # Download the binary from GitHub.
 set(Version "1.6.1")
-set(LibPath "${CMAKE_CURRENT_SOURCE_DIR}/windows.zip")
+set(LibPath "${CMAKE_CURRENT_SOURCE_DIR}/windows.tar.gz")
 if(NOT EXISTS ${LibPath})
   file(DOWNLOAD
-    "https://github.com/erikas-taroza/simple_audio/releases/download/v${Version}/windows.zip"
+    "https://github.com/erikas-taroza/simple_audio/releases/download/v${Version}/windows.tar.gz"
     ${LibPath}
     TLS_VERIFY ON
   )
 
-  file(ARCHIVE_EXTRACT INPUT ${LibPath} DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${LibPath}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 endif()
 
 # List of absolute paths to libraries that should be bundled with the plugin.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -53,9 +53,11 @@ if(NOT EXISTS ${LibPath})
     ${LibPath}
     TLS_VERIFY ON
   )
+endif()
 
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/simple_audio.dll")
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${LibPath}
+    COMMAND ${CMAKE_COMMAND} -E tar -xzf windows.tar.gz
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()


### PR DESCRIPTION
The cmake unzip command released in v3.18. This may cause issues for users that have an older version of cmake (as seen in #36). Instead, the release files will be archived with tar and we can use the tar command from cmake to extract the files.