### PR TITLE
Extract `ios.zip` to `simple_audio.xcframework` directory

### DIFF
--- a/ios/simple_audio.podspec
+++ b/ios/simple_audio.podspec
@@ -8,7 +8,7 @@ cd Frameworks
 if [ ! -d ios.zip ]
 then
   curl -L "#{lib_url}" -o ios.zip
-  unzip ios.zip
+  unzip ios.zip -d 'simple_audio.xcframework'
 fi
 cd ..
 `


### PR DESCRIPTION
Fixes #30. The example app now compiles on iOS.