### PR TITLE
Gapless playback improvements

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,8 +50,10 @@ class _MyAppState extends State<MyApp> {
     },
   );
 
-  PlaybackState playbackState = PlaybackState.done;
-  bool get isPlaying => playbackState == PlaybackState.play;
+  PlaybackState playbackState = PlaybackState.stop;
+  bool get isPlaying =>
+      playbackState == PlaybackState.play ||
+      playbackState == PlaybackState.preloadPlayed;
 
   bool get isMuted => volume == 0;
   double trueVolume = 1;
@@ -157,6 +159,7 @@ class _MyAppState extends State<MyApp> {
                     onPressed: () async {
                       if (!await player.hasPreloaded) {
                         debugPrint("No preloaded file to play!");
+                        return;
                       }
 
                       debugPrint("Playing preloaded file.");
@@ -170,6 +173,7 @@ class _MyAppState extends State<MyApp> {
                     onPressed: () async {
                       if (!await player.hasPreloaded) {
                         debugPrint("No preloaded file to clear!");
+                        return;
                       }
 
                       debugPrint("Cleared preloaded file.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -164,6 +164,18 @@ class _MyAppState extends State<MyApp> {
                       await player.playPreload();
                     },
                   ),
+                  const SizedBox(width: 5),
+                  ElevatedButton(
+                    child: const Text("Clear Preload"),
+                    onPressed: () async {
+                      if (!await player.hasPreloaded) {
+                        debugPrint("No preloaded file to clear!");
+                      }
+
+                      debugPrint("Cleared preloaded file.");
+                      await player.clearPreload();
+                    },
+                  ),
                 ],
               ),
               const SizedBox(height: 20),

--- a/ios/Classes/bridge_generated.h
+++ b/ios/Classes/bridge_generated.h
@@ -79,6 +79,8 @@ void wire_preload__method__Player(int64_t port_,
 
 void wire_play_preload__method__Player(int64_t port_, struct wire_Player *that);
 
+void wire_clear_preload__method__Player(int64_t port_, struct wire_Player *that);
+
 void wire_play__method__Player(int64_t port_, struct wire_Player *that);
 
 void wire_pause__method__Player(int64_t port_, struct wire_Player *that);
@@ -130,6 +132,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_open__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_preload__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_play_preload__method__Player);
+    dummy_var ^= ((int64_t) (void*) wire_clear_preload__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_play__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_pause__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_stop__method__Player);

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -62,7 +62,8 @@ abstract class SimpleAudio {
 
   FlutterRustBridgeTaskConstMeta get kOpenMethodPlayerConstMeta;
 
-  /// Preloads a file or network resource for reading and playing.
+  /// Preloads a file or network resource for playback.
+  /// The preloaded file is automatically played when the current file is finished playing.
   ///
   /// Use this method if you want gapless playback. It reduces
   /// the time spent loading between tracks (especially important
@@ -72,10 +73,15 @@ abstract class SimpleAudio {
 
   FlutterRustBridgeTaskConstMeta get kPreloadMethodPlayerConstMeta;
 
-  /// Plays the preloaded item from `preload`. The file starts playing automatically.
+  /// Plays the preloaded file.
   Future<void> playPreloadMethodPlayer({required Player that, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPlayPreloadMethodPlayerConstMeta;
+
+  /// Clears the preloaded file so that it doesn't play when the current file is finished.
+  Future<void> clearPreloadMethodPlayer({required Player that, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kClearPreloadMethodPlayerConstMeta;
 
   Future<void> playMethodPlayer({required Player that, dynamic hint});
 
@@ -298,7 +304,8 @@ class Player {
         autoplay: autoplay,
       );
 
-  /// Preloads a file or network resource for reading and playing.
+  /// Preloads a file or network resource for playback.
+  /// The preloaded file is automatically played when the current file is finished playing.
   ///
   /// Use this method if you want gapless playback. It reduces
   /// the time spent loading between tracks (especially important
@@ -309,8 +316,13 @@ class Player {
         path: path,
       );
 
-  /// Plays the preloaded item from `preload`. The file starts playing automatically.
+  /// Plays the preloaded file.
   Future<void> playPreload({dynamic hint}) => bridge.playPreloadMethodPlayer(
+        that: this,
+      );
+
+  /// Clears the preloaded file so that it doesn't play when the current file is finished.
+  Future<void> clearPreload({dynamic hint}) => bridge.clearPreloadMethodPlayer(
         that: this,
       );
 

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -245,6 +245,9 @@ enum PlaybackState {
 
   /// The player was stopped
   stop,
+
+  /// The player has automatically started playing the preloaded file.
+  preloadPlayed,
 }
 
 class Player {

--- a/lib/src/bridge_definitions.freezed.dart
+++ b/lib/src/bridge_definitions.freezed.dart
@@ -97,10 +97,10 @@ class _$CallbackCopyWithImpl<$Res, $Val extends Callback>
 }
 
 /// @nodoc
-abstract class _$$Callback_ErrorImplCopyWith<$Res> {
-  factory _$$Callback_ErrorImplCopyWith(_$Callback_ErrorImpl value,
-          $Res Function(_$Callback_ErrorImpl) then) =
-      __$$Callback_ErrorImplCopyWithImpl<$Res>;
+abstract class _$$Callback_ErrorCopyWith<$Res> {
+  factory _$$Callback_ErrorCopyWith(
+          _$Callback_Error value, $Res Function(_$Callback_Error) then) =
+      __$$Callback_ErrorCopyWithImpl<$Res>;
   @useResult
   $Res call({Error field0});
 
@@ -108,11 +108,11 @@ abstract class _$$Callback_ErrorImplCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$Callback_ErrorImplCopyWithImpl<$Res>
-    extends _$CallbackCopyWithImpl<$Res, _$Callback_ErrorImpl>
-    implements _$$Callback_ErrorImplCopyWith<$Res> {
-  __$$Callback_ErrorImplCopyWithImpl(
-      _$Callback_ErrorImpl _value, $Res Function(_$Callback_ErrorImpl) _then)
+class __$$Callback_ErrorCopyWithImpl<$Res>
+    extends _$CallbackCopyWithImpl<$Res, _$Callback_Error>
+    implements _$$Callback_ErrorCopyWith<$Res> {
+  __$$Callback_ErrorCopyWithImpl(
+      _$Callback_Error _value, $Res Function(_$Callback_Error) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -120,7 +120,7 @@ class __$$Callback_ErrorImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$Callback_ErrorImpl(
+    return _then(_$Callback_Error(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -139,8 +139,8 @@ class __$$Callback_ErrorImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$Callback_ErrorImpl implements Callback_Error {
-  const _$Callback_ErrorImpl(this.field0);
+class _$Callback_Error implements Callback_Error {
+  const _$Callback_Error(this.field0);
 
   @override
   final Error field0;
@@ -154,7 +154,7 @@ class _$Callback_ErrorImpl implements Callback_Error {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Callback_ErrorImpl &&
+            other is _$Callback_Error &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -164,9 +164,8 @@ class _$Callback_ErrorImpl implements Callback_Error {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$Callback_ErrorImplCopyWith<_$Callback_ErrorImpl> get copyWith =>
-      __$$Callback_ErrorImplCopyWithImpl<_$Callback_ErrorImpl>(
-          this, _$identity);
+  _$$Callback_ErrorCopyWith<_$Callback_Error> get copyWith =>
+      __$$Callback_ErrorCopyWithImpl<_$Callback_Error>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -255,37 +254,36 @@ class _$Callback_ErrorImpl implements Callback_Error {
 }
 
 abstract class Callback_Error implements Callback {
-  const factory Callback_Error(final Error field0) = _$Callback_ErrorImpl;
+  const factory Callback_Error(final Error field0) = _$Callback_Error;
 
   Error get field0;
   @JsonKey(ignore: true)
-  _$$Callback_ErrorImplCopyWith<_$Callback_ErrorImpl> get copyWith =>
+  _$$Callback_ErrorCopyWith<_$Callback_Error> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$Callback_MediaControlSkipPrevImplCopyWith<$Res> {
-  factory _$$Callback_MediaControlSkipPrevImplCopyWith(
-          _$Callback_MediaControlSkipPrevImpl value,
-          $Res Function(_$Callback_MediaControlSkipPrevImpl) then) =
-      __$$Callback_MediaControlSkipPrevImplCopyWithImpl<$Res>;
+abstract class _$$Callback_MediaControlSkipPrevCopyWith<$Res> {
+  factory _$$Callback_MediaControlSkipPrevCopyWith(
+          _$Callback_MediaControlSkipPrev value,
+          $Res Function(_$Callback_MediaControlSkipPrev) then) =
+      __$$Callback_MediaControlSkipPrevCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Callback_MediaControlSkipPrevImplCopyWithImpl<$Res>
-    extends _$CallbackCopyWithImpl<$Res, _$Callback_MediaControlSkipPrevImpl>
-    implements _$$Callback_MediaControlSkipPrevImplCopyWith<$Res> {
-  __$$Callback_MediaControlSkipPrevImplCopyWithImpl(
-      _$Callback_MediaControlSkipPrevImpl _value,
-      $Res Function(_$Callback_MediaControlSkipPrevImpl) _then)
+class __$$Callback_MediaControlSkipPrevCopyWithImpl<$Res>
+    extends _$CallbackCopyWithImpl<$Res, _$Callback_MediaControlSkipPrev>
+    implements _$$Callback_MediaControlSkipPrevCopyWith<$Res> {
+  __$$Callback_MediaControlSkipPrevCopyWithImpl(
+      _$Callback_MediaControlSkipPrev _value,
+      $Res Function(_$Callback_MediaControlSkipPrev) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$Callback_MediaControlSkipPrevImpl
-    implements Callback_MediaControlSkipPrev {
-  const _$Callback_MediaControlSkipPrevImpl();
+class _$Callback_MediaControlSkipPrev implements Callback_MediaControlSkipPrev {
+  const _$Callback_MediaControlSkipPrev();
 
   @override
   String toString() {
@@ -296,7 +294,7 @@ class _$Callback_MediaControlSkipPrevImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Callback_MediaControlSkipPrevImpl);
+            other is _$Callback_MediaControlSkipPrev);
   }
 
   @override
@@ -390,32 +388,31 @@ class _$Callback_MediaControlSkipPrevImpl
 
 abstract class Callback_MediaControlSkipPrev implements Callback {
   const factory Callback_MediaControlSkipPrev() =
-      _$Callback_MediaControlSkipPrevImpl;
+      _$Callback_MediaControlSkipPrev;
 }
 
 /// @nodoc
-abstract class _$$Callback_MediaControlSkipNextImplCopyWith<$Res> {
-  factory _$$Callback_MediaControlSkipNextImplCopyWith(
-          _$Callback_MediaControlSkipNextImpl value,
-          $Res Function(_$Callback_MediaControlSkipNextImpl) then) =
-      __$$Callback_MediaControlSkipNextImplCopyWithImpl<$Res>;
+abstract class _$$Callback_MediaControlSkipNextCopyWith<$Res> {
+  factory _$$Callback_MediaControlSkipNextCopyWith(
+          _$Callback_MediaControlSkipNext value,
+          $Res Function(_$Callback_MediaControlSkipNext) then) =
+      __$$Callback_MediaControlSkipNextCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Callback_MediaControlSkipNextImplCopyWithImpl<$Res>
-    extends _$CallbackCopyWithImpl<$Res, _$Callback_MediaControlSkipNextImpl>
-    implements _$$Callback_MediaControlSkipNextImplCopyWith<$Res> {
-  __$$Callback_MediaControlSkipNextImplCopyWithImpl(
-      _$Callback_MediaControlSkipNextImpl _value,
-      $Res Function(_$Callback_MediaControlSkipNextImpl) _then)
+class __$$Callback_MediaControlSkipNextCopyWithImpl<$Res>
+    extends _$CallbackCopyWithImpl<$Res, _$Callback_MediaControlSkipNext>
+    implements _$$Callback_MediaControlSkipNextCopyWith<$Res> {
+  __$$Callback_MediaControlSkipNextCopyWithImpl(
+      _$Callback_MediaControlSkipNext _value,
+      $Res Function(_$Callback_MediaControlSkipNext) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$Callback_MediaControlSkipNextImpl
-    implements Callback_MediaControlSkipNext {
-  const _$Callback_MediaControlSkipNextImpl();
+class _$Callback_MediaControlSkipNext implements Callback_MediaControlSkipNext {
+  const _$Callback_MediaControlSkipNext();
 
   @override
   String toString() {
@@ -426,7 +423,7 @@ class _$Callback_MediaControlSkipNextImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Callback_MediaControlSkipNextImpl);
+            other is _$Callback_MediaControlSkipNext);
   }
 
   @override
@@ -520,31 +517,29 @@ class _$Callback_MediaControlSkipNextImpl
 
 abstract class Callback_MediaControlSkipNext implements Callback {
   const factory Callback_MediaControlSkipNext() =
-      _$Callback_MediaControlSkipNextImpl;
+      _$Callback_MediaControlSkipNext;
 }
 
 /// @nodoc
-abstract class _$$Callback_PlaybackLoopedImplCopyWith<$Res> {
-  factory _$$Callback_PlaybackLoopedImplCopyWith(
-          _$Callback_PlaybackLoopedImpl value,
-          $Res Function(_$Callback_PlaybackLoopedImpl) then) =
-      __$$Callback_PlaybackLoopedImplCopyWithImpl<$Res>;
+abstract class _$$Callback_PlaybackLoopedCopyWith<$Res> {
+  factory _$$Callback_PlaybackLoopedCopyWith(_$Callback_PlaybackLooped value,
+          $Res Function(_$Callback_PlaybackLooped) then) =
+      __$$Callback_PlaybackLoopedCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Callback_PlaybackLoopedImplCopyWithImpl<$Res>
-    extends _$CallbackCopyWithImpl<$Res, _$Callback_PlaybackLoopedImpl>
-    implements _$$Callback_PlaybackLoopedImplCopyWith<$Res> {
-  __$$Callback_PlaybackLoopedImplCopyWithImpl(
-      _$Callback_PlaybackLoopedImpl _value,
-      $Res Function(_$Callback_PlaybackLoopedImpl) _then)
+class __$$Callback_PlaybackLoopedCopyWithImpl<$Res>
+    extends _$CallbackCopyWithImpl<$Res, _$Callback_PlaybackLooped>
+    implements _$$Callback_PlaybackLoopedCopyWith<$Res> {
+  __$$Callback_PlaybackLoopedCopyWithImpl(_$Callback_PlaybackLooped _value,
+      $Res Function(_$Callback_PlaybackLooped) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$Callback_PlaybackLoopedImpl implements Callback_PlaybackLooped {
-  const _$Callback_PlaybackLoopedImpl();
+class _$Callback_PlaybackLooped implements Callback_PlaybackLooped {
+  const _$Callback_PlaybackLooped();
 
   @override
   String toString() {
@@ -555,7 +550,7 @@ class _$Callback_PlaybackLoopedImpl implements Callback_PlaybackLooped {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Callback_PlaybackLoopedImpl);
+            other is _$Callback_PlaybackLooped);
   }
 
   @override
@@ -648,31 +643,31 @@ class _$Callback_PlaybackLoopedImpl implements Callback_PlaybackLooped {
 }
 
 abstract class Callback_PlaybackLooped implements Callback {
-  const factory Callback_PlaybackLooped() = _$Callback_PlaybackLoopedImpl;
+  const factory Callback_PlaybackLooped() = _$Callback_PlaybackLooped;
 }
 
 /// @nodoc
-abstract class _$$Callback_DurationCalculatedImplCopyWith<$Res> {
-  factory _$$Callback_DurationCalculatedImplCopyWith(
-          _$Callback_DurationCalculatedImpl value,
-          $Res Function(_$Callback_DurationCalculatedImpl) then) =
-      __$$Callback_DurationCalculatedImplCopyWithImpl<$Res>;
+abstract class _$$Callback_DurationCalculatedCopyWith<$Res> {
+  factory _$$Callback_DurationCalculatedCopyWith(
+          _$Callback_DurationCalculated value,
+          $Res Function(_$Callback_DurationCalculated) then) =
+      __$$Callback_DurationCalculatedCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Callback_DurationCalculatedImplCopyWithImpl<$Res>
-    extends _$CallbackCopyWithImpl<$Res, _$Callback_DurationCalculatedImpl>
-    implements _$$Callback_DurationCalculatedImplCopyWith<$Res> {
-  __$$Callback_DurationCalculatedImplCopyWithImpl(
-      _$Callback_DurationCalculatedImpl _value,
-      $Res Function(_$Callback_DurationCalculatedImpl) _then)
+class __$$Callback_DurationCalculatedCopyWithImpl<$Res>
+    extends _$CallbackCopyWithImpl<$Res, _$Callback_DurationCalculated>
+    implements _$$Callback_DurationCalculatedCopyWith<$Res> {
+  __$$Callback_DurationCalculatedCopyWithImpl(
+      _$Callback_DurationCalculated _value,
+      $Res Function(_$Callback_DurationCalculated) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$Callback_DurationCalculatedImpl implements Callback_DurationCalculated {
-  const _$Callback_DurationCalculatedImpl();
+class _$Callback_DurationCalculated implements Callback_DurationCalculated {
+  const _$Callback_DurationCalculated();
 
   @override
   String toString() {
@@ -683,7 +678,7 @@ class _$Callback_DurationCalculatedImpl implements Callback_DurationCalculated {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Callback_DurationCalculatedImpl);
+            other is _$Callback_DurationCalculated);
   }
 
   @override
@@ -776,8 +771,7 @@ class _$Callback_DurationCalculatedImpl implements Callback_DurationCalculated {
 }
 
 abstract class Callback_DurationCalculated implements Callback {
-  const factory Callback_DurationCalculated() =
-      _$Callback_DurationCalculatedImpl;
+  const factory Callback_DurationCalculated() = _$Callback_DurationCalculated;
 }
 
 /// @nodoc
@@ -872,22 +866,22 @@ class _$ErrorCopyWithImpl<$Res, $Val extends Error>
 }
 
 /// @nodoc
-abstract class _$$Error_NetworkStreamImplCopyWith<$Res>
+abstract class _$$Error_NetworkStreamCopyWith<$Res>
     implements $ErrorCopyWith<$Res> {
-  factory _$$Error_NetworkStreamImplCopyWith(_$Error_NetworkStreamImpl value,
-          $Res Function(_$Error_NetworkStreamImpl) then) =
-      __$$Error_NetworkStreamImplCopyWithImpl<$Res>;
+  factory _$$Error_NetworkStreamCopyWith(_$Error_NetworkStream value,
+          $Res Function(_$Error_NetworkStream) then) =
+      __$$Error_NetworkStreamCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$Error_NetworkStreamImplCopyWithImpl<$Res>
-    extends _$ErrorCopyWithImpl<$Res, _$Error_NetworkStreamImpl>
-    implements _$$Error_NetworkStreamImplCopyWith<$Res> {
-  __$$Error_NetworkStreamImplCopyWithImpl(_$Error_NetworkStreamImpl _value,
-      $Res Function(_$Error_NetworkStreamImpl) _then)
+class __$$Error_NetworkStreamCopyWithImpl<$Res>
+    extends _$ErrorCopyWithImpl<$Res, _$Error_NetworkStream>
+    implements _$$Error_NetworkStreamCopyWith<$Res> {
+  __$$Error_NetworkStreamCopyWithImpl(
+      _$Error_NetworkStream _value, $Res Function(_$Error_NetworkStream) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -895,7 +889,7 @@ class __$$Error_NetworkStreamImplCopyWithImpl<$Res>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$Error_NetworkStreamImpl(
+    return _then(_$Error_NetworkStream(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -906,8 +900,8 @@ class __$$Error_NetworkStreamImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$Error_NetworkStreamImpl implements Error_NetworkStream {
-  const _$Error_NetworkStreamImpl({required this.message});
+class _$Error_NetworkStream implements Error_NetworkStream {
+  const _$Error_NetworkStream({required this.message});
 
   /// The error message.
   @override
@@ -922,7 +916,7 @@ class _$Error_NetworkStreamImpl implements Error_NetworkStream {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Error_NetworkStreamImpl &&
+            other is _$Error_NetworkStream &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -932,8 +926,8 @@ class _$Error_NetworkStreamImpl implements Error_NetworkStream {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$Error_NetworkStreamImplCopyWith<_$Error_NetworkStreamImpl> get copyWith =>
-      __$$Error_NetworkStreamImplCopyWithImpl<_$Error_NetworkStreamImpl>(
+  _$$Error_NetworkStreamCopyWith<_$Error_NetworkStream> get copyWith =>
+      __$$Error_NetworkStreamCopyWithImpl<_$Error_NetworkStream>(
           this, _$identity);
 
   @override
@@ -1013,7 +1007,7 @@ class _$Error_NetworkStreamImpl implements Error_NetworkStream {
 
 abstract class Error_NetworkStream implements Error {
   const factory Error_NetworkStream({required final String message}) =
-      _$Error_NetworkStreamImpl;
+      _$Error_NetworkStream;
 
   @override
 
@@ -1021,27 +1015,26 @@ abstract class Error_NetworkStream implements Error {
   String get message;
   @override
   @JsonKey(ignore: true)
-  _$$Error_NetworkStreamImplCopyWith<_$Error_NetworkStreamImpl> get copyWith =>
+  _$$Error_NetworkStreamCopyWith<_$Error_NetworkStream> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$Error_DecodeImplCopyWith<$Res>
-    implements $ErrorCopyWith<$Res> {
-  factory _$$Error_DecodeImplCopyWith(
-          _$Error_DecodeImpl value, $Res Function(_$Error_DecodeImpl) then) =
-      __$$Error_DecodeImplCopyWithImpl<$Res>;
+abstract class _$$Error_DecodeCopyWith<$Res> implements $ErrorCopyWith<$Res> {
+  factory _$$Error_DecodeCopyWith(
+          _$Error_Decode value, $Res Function(_$Error_Decode) then) =
+      __$$Error_DecodeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$Error_DecodeImplCopyWithImpl<$Res>
-    extends _$ErrorCopyWithImpl<$Res, _$Error_DecodeImpl>
-    implements _$$Error_DecodeImplCopyWith<$Res> {
-  __$$Error_DecodeImplCopyWithImpl(
-      _$Error_DecodeImpl _value, $Res Function(_$Error_DecodeImpl) _then)
+class __$$Error_DecodeCopyWithImpl<$Res>
+    extends _$ErrorCopyWithImpl<$Res, _$Error_Decode>
+    implements _$$Error_DecodeCopyWith<$Res> {
+  __$$Error_DecodeCopyWithImpl(
+      _$Error_Decode _value, $Res Function(_$Error_Decode) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1049,7 +1042,7 @@ class __$$Error_DecodeImplCopyWithImpl<$Res>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$Error_DecodeImpl(
+    return _then(_$Error_Decode(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -1060,8 +1053,8 @@ class __$$Error_DecodeImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$Error_DecodeImpl implements Error_Decode {
-  const _$Error_DecodeImpl({required this.message});
+class _$Error_Decode implements Error_Decode {
+  const _$Error_Decode({required this.message});
 
   /// The error message.
   @override
@@ -1076,7 +1069,7 @@ class _$Error_DecodeImpl implements Error_Decode {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Error_DecodeImpl &&
+            other is _$Error_Decode &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -1086,8 +1079,8 @@ class _$Error_DecodeImpl implements Error_Decode {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$Error_DecodeImplCopyWith<_$Error_DecodeImpl> get copyWith =>
-      __$$Error_DecodeImplCopyWithImpl<_$Error_DecodeImpl>(this, _$identity);
+  _$$Error_DecodeCopyWith<_$Error_Decode> get copyWith =>
+      __$$Error_DecodeCopyWithImpl<_$Error_Decode>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1165,8 +1158,7 @@ class _$Error_DecodeImpl implements Error_Decode {
 }
 
 abstract class Error_Decode implements Error {
-  const factory Error_Decode({required final String message}) =
-      _$Error_DecodeImpl;
+  const factory Error_Decode({required final String message}) = _$Error_Decode;
 
   @override
 
@@ -1174,26 +1166,26 @@ abstract class Error_Decode implements Error {
   String get message;
   @override
   @JsonKey(ignore: true)
-  _$$Error_DecodeImplCopyWith<_$Error_DecodeImpl> get copyWith =>
+  _$$Error_DecodeCopyWith<_$Error_Decode> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$Error_OpenImplCopyWith<$Res> implements $ErrorCopyWith<$Res> {
-  factory _$$Error_OpenImplCopyWith(
-          _$Error_OpenImpl value, $Res Function(_$Error_OpenImpl) then) =
-      __$$Error_OpenImplCopyWithImpl<$Res>;
+abstract class _$$Error_OpenCopyWith<$Res> implements $ErrorCopyWith<$Res> {
+  factory _$$Error_OpenCopyWith(
+          _$Error_Open value, $Res Function(_$Error_Open) then) =
+      __$$Error_OpenCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$Error_OpenImplCopyWithImpl<$Res>
-    extends _$ErrorCopyWithImpl<$Res, _$Error_OpenImpl>
-    implements _$$Error_OpenImplCopyWith<$Res> {
-  __$$Error_OpenImplCopyWithImpl(
-      _$Error_OpenImpl _value, $Res Function(_$Error_OpenImpl) _then)
+class __$$Error_OpenCopyWithImpl<$Res>
+    extends _$ErrorCopyWithImpl<$Res, _$Error_Open>
+    implements _$$Error_OpenCopyWith<$Res> {
+  __$$Error_OpenCopyWithImpl(
+      _$Error_Open _value, $Res Function(_$Error_Open) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1201,7 +1193,7 @@ class __$$Error_OpenImplCopyWithImpl<$Res>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$Error_OpenImpl(
+    return _then(_$Error_Open(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -1212,8 +1204,8 @@ class __$$Error_OpenImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$Error_OpenImpl implements Error_Open {
-  const _$Error_OpenImpl({required this.message});
+class _$Error_Open implements Error_Open {
+  const _$Error_Open({required this.message});
 
   /// The error message.
   @override
@@ -1228,7 +1220,7 @@ class _$Error_OpenImpl implements Error_Open {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Error_OpenImpl &&
+            other is _$Error_Open &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -1238,8 +1230,8 @@ class _$Error_OpenImpl implements Error_Open {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$Error_OpenImplCopyWith<_$Error_OpenImpl> get copyWith =>
-      __$$Error_OpenImplCopyWithImpl<_$Error_OpenImpl>(this, _$identity);
+  _$$Error_OpenCopyWith<_$Error_Open> get copyWith =>
+      __$$Error_OpenCopyWithImpl<_$Error_Open>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1317,7 +1309,7 @@ class _$Error_OpenImpl implements Error_Open {
 }
 
 abstract class Error_Open implements Error {
-  const factory Error_Open({required final String message}) = _$Error_OpenImpl;
+  const factory Error_Open({required final String message}) = _$Error_Open;
 
   @override
 
@@ -1325,27 +1317,26 @@ abstract class Error_Open implements Error {
   String get message;
   @override
   @JsonKey(ignore: true)
-  _$$Error_OpenImplCopyWith<_$Error_OpenImpl> get copyWith =>
+  _$$Error_OpenCopyWith<_$Error_Open> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$Error_PreloadImplCopyWith<$Res>
-    implements $ErrorCopyWith<$Res> {
-  factory _$$Error_PreloadImplCopyWith(
-          _$Error_PreloadImpl value, $Res Function(_$Error_PreloadImpl) then) =
-      __$$Error_PreloadImplCopyWithImpl<$Res>;
+abstract class _$$Error_PreloadCopyWith<$Res> implements $ErrorCopyWith<$Res> {
+  factory _$$Error_PreloadCopyWith(
+          _$Error_Preload value, $Res Function(_$Error_Preload) then) =
+      __$$Error_PreloadCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$Error_PreloadImplCopyWithImpl<$Res>
-    extends _$ErrorCopyWithImpl<$Res, _$Error_PreloadImpl>
-    implements _$$Error_PreloadImplCopyWith<$Res> {
-  __$$Error_PreloadImplCopyWithImpl(
-      _$Error_PreloadImpl _value, $Res Function(_$Error_PreloadImpl) _then)
+class __$$Error_PreloadCopyWithImpl<$Res>
+    extends _$ErrorCopyWithImpl<$Res, _$Error_Preload>
+    implements _$$Error_PreloadCopyWith<$Res> {
+  __$$Error_PreloadCopyWithImpl(
+      _$Error_Preload _value, $Res Function(_$Error_Preload) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1353,7 +1344,7 @@ class __$$Error_PreloadImplCopyWithImpl<$Res>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$Error_PreloadImpl(
+    return _then(_$Error_Preload(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -1364,8 +1355,8 @@ class __$$Error_PreloadImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$Error_PreloadImpl implements Error_Preload {
-  const _$Error_PreloadImpl({required this.message});
+class _$Error_Preload implements Error_Preload {
+  const _$Error_Preload({required this.message});
 
   /// The error message.
   @override
@@ -1380,7 +1371,7 @@ class _$Error_PreloadImpl implements Error_Preload {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$Error_PreloadImpl &&
+            other is _$Error_Preload &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -1390,8 +1381,8 @@ class _$Error_PreloadImpl implements Error_Preload {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$Error_PreloadImplCopyWith<_$Error_PreloadImpl> get copyWith =>
-      __$$Error_PreloadImplCopyWithImpl<_$Error_PreloadImpl>(this, _$identity);
+  _$$Error_PreloadCopyWith<_$Error_Preload> get copyWith =>
+      __$$Error_PreloadCopyWithImpl<_$Error_Preload>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1470,7 +1461,7 @@ class _$Error_PreloadImpl implements Error_Preload {
 
 abstract class Error_Preload implements Error {
   const factory Error_Preload({required final String message}) =
-      _$Error_PreloadImpl;
+      _$Error_Preload;
 
   @override
 
@@ -1478,6 +1469,6 @@ abstract class Error_Preload implements Error {
   String get message;
   @override
   @JsonKey(ignore: true)
-  _$$Error_PreloadImplCopyWith<_$Error_PreloadImpl> get copyWith =>
+  _$$Error_PreloadCopyWith<_$Error_Preload> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/bridge_generated.dart
+++ b/lib/src/bridge_generated.dart
@@ -249,6 +249,25 @@ class SimpleAudioImpl implements SimpleAudio {
         argNames: ["that"],
       );
 
+  Future<void> clearPreloadMethodPlayer({required Player that, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_player(that);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) =>
+          _platform.inner.wire_clear_preload__method__Player(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      parseErrorData: null,
+      constMeta: kClearPreloadMethodPlayerConstMeta,
+      argValues: [that],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kClearPreloadMethodPlayerConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "clear_preload__method__Player",
+        argNames: ["that"],
+      );
+
   Future<void> playMethodPlayer({required Player that, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_player(that);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -961,6 +980,24 @@ class SimpleAudioWire implements FlutterRustBridgeWireBase {
               ffi.Pointer<wire_Player>)>>('wire_play_preload__method__Player');
   late final _wire_play_preload__method__Player =
       _wire_play_preload__method__PlayerPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_Player>)>();
+
+  void wire_clear_preload__method__Player(
+    int port_,
+    ffi.Pointer<wire_Player> that,
+  ) {
+    return _wire_clear_preload__method__Player(
+      port_,
+      that,
+    );
+  }
+
+  late final _wire_clear_preload__method__PlayerPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_Player>)>>('wire_clear_preload__method__Player');
+  late final _wire_clear_preload__method__Player =
+      _wire_clear_preload__method__PlayerPtr
           .asFunction<void Function(int, ffi.Pointer<wire_Player>)>();
 
   void wire_play__method__Player(

--- a/lib/src/simple_audio.dart
+++ b/lib/src/simple_audio.dart
@@ -422,6 +422,7 @@ class SimpleAudio {
   }
 
   /// Preloads a file or network resource for reading and playing.
+  /// The preloaded file is automatically played when the current file is finished playing.
   ///
   /// Use this method if you want gapless playback. It reduces
   /// the time spent loading between tracks (especially important
@@ -432,7 +433,7 @@ class SimpleAudio {
     return await _player.preload(path: path);
   }
 
-  /// Plays the preloaded item from [preload]. The file starts playing automatically.
+  /// Plays the preloaded file.
   Future<void> playPreload() async {
     await _player.playPreload();
 
@@ -441,4 +442,7 @@ class SimpleAudio {
       {"state": PlaybackState.play.index, "position": 0},
     );
   }
+
+  /// Clears the preloaded file so that it doesn't play when the current file is finished.
+  Future<void> clearPreload() async => await _player.clearPreload();
 }

--- a/macos/Classes/bridge_generated.h
+++ b/macos/Classes/bridge_generated.h
@@ -79,6 +79,8 @@ void wire_preload__method__Player(int64_t port_,
 
 void wire_play_preload__method__Player(int64_t port_, struct wire_Player *that);
 
+void wire_clear_preload__method__Player(int64_t port_, struct wire_Player *that);
+
 void wire_play__method__Player(int64_t port_, struct wire_Player *that);
 
 void wire_pause__method__Player(int64_t port_, struct wire_Player *that);
@@ -130,6 +132,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_open__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_preload__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_play_preload__method__Player);
+    dummy_var ^= ((int64_t) (void*) wire_clear_preload__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_play__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_pause__method__Player);
     dummy_var ^= ((int64_t) (void*) wire_stop__method__Player);

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -214,7 +214,8 @@ impl Player
         Ok(())
     }
 
-    /// Preloads a file or network resource for reading and playing.
+    /// Preloads a file or network resource for playback.
+    /// The preloaded file is automatically played when the current file is finished playing.
     ///
     /// Use this method if you want gapless playback. It reduces
     /// the time spent loading between tracks (especially important
@@ -244,12 +245,21 @@ impl Player
         }
     }
 
-    /// Plays the preloaded item from `preload`. The file starts playing automatically.
+    /// Plays the preloaded file.
     pub fn play_preload(&self)
     {
         self.controls
             .event_handler()
             .send(PlayerEvent::PlayPreload)
+            .unwrap();
+    }
+
+    /// Clears the preloaded file so that it doesn't play when the current file is finished.
+    pub fn clear_preload(&self)
+    {
+        self.controls
+            .event_handler()
+            .send(PlayerEvent::ClearPreload)
             .unwrap();
     }
 

--- a/rust/src/audio/controls.rs
+++ b/rust/src/audio/controls.rs
@@ -143,4 +143,5 @@ pub enum PlayerEvent
     DeviceChanged,
     Preload(Box<dyn MediaSource>, Arc<AtomicBool>),
     PlayPreload,
+    ClearPreload,
 }

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -118,22 +118,24 @@ impl CpalOutput
         })
     }
 
-    pub fn play(&self)
+    pub fn play(&mut self)
     {
         if self.is_playing {
             return;
         }
 
         _ = self.stream.play();
+        self.is_playing = true;
     }
 
-    pub fn pause(&self)
+    pub fn pause(&mut self)
     {
         if !self.is_playing {
             return;
         }
 
         _ = self.stream.pause();
+        self.is_playing = false;
     }
 
     fn get_config() -> anyhow::Result<(Device, StreamConfig, usize)>

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -29,13 +29,13 @@ use super::{
 };
 
 /// The default output volume is way too high.
-/// Multiplying the volume input by this number
-/// will help to reduce it.
 const BASE_VOLUME: f32 = 0.8;
 
 pub struct CpalOutput
 {
     stream: Stream,
+    /// A safety to prevent playing/pausing the stream when it is already in that state.
+    /// If this happens, the Android implementation won't work.
     is_playing: bool,
     pub stream_config: StreamConfig,
     pub ring_buffer_reader: BlockingRb<f32, Consumer>,

--- a/rust/src/audio/cpal_output.rs
+++ b/rust/src/audio/cpal_output.rs
@@ -36,6 +36,7 @@ const BASE_VOLUME: f32 = 0.8;
 pub struct CpalOutput
 {
     stream: Stream,
+    is_playing: bool,
     pub stream_config: StreamConfig,
     pub ring_buffer_reader: BlockingRb<f32, Consumer>,
     pub ring_buffer_writer: BlockingRb<f32, Producer>,
@@ -107,10 +108,10 @@ impl CpalOutput
         );
 
         let stream = stream.context("Could not build the stream.")?;
-        stream.play()?;
 
         Ok(Self {
             stream,
+            is_playing: false,
             stream_config,
             ring_buffer_reader,
             ring_buffer_writer,
@@ -119,11 +120,19 @@ impl CpalOutput
 
     pub fn play(&self)
     {
+        if self.is_playing {
+            return;
+        }
+
         _ = self.stream.play();
     }
 
     pub fn pause(&self)
     {
+        if !self.is_playing {
+            return;
+        }
+
         _ = self.stream.pause();
     }
 

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -207,6 +207,10 @@ impl Decoder
 
                     Player::internal_play(&self.controls);
                 }
+                PlayerEvent::ClearPreload => {
+                    self.preload_playback = None;
+                    self.controls.set_is_file_preloaded(false);
+                }
             },
         }
 

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -185,8 +185,9 @@ impl Decoder
                     self.playback = None;
                 }
                 PlayerEvent::DeviceChanged => {
-                    self.cpal_output = CpalOutput::new(self.controls.clone())?;
                     Player::internal_pause(&self.controls);
+                    self.cpal_output = CpalOutput::new(self.controls.clone())?;
+                    self.output_writer = None;
                 }
                 PlayerEvent::Preload(source, buffer_signal) => {
                     self.preload_playback = None;

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -166,6 +166,7 @@ impl Decoder
             None => (),
             Some(message) => match message {
                 PlayerEvent::Open(source, buffer_signal) => {
+                    self.cpal_output.ring_buffer_reader.skip_all();
                     self.output_writer = None;
                     self.playback = Some(Self::open(source, buffer_signal)?);
                 }

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -46,7 +46,10 @@ use crate::{
     },
 };
 
-use super::{controls::*, cpal_output::CpalOutput};
+use super::{
+    controls::*,
+    cpal_output::{CpalOutput, OutputWriter},
+};
 
 lazy_static! {
     static ref CODEC_REGISTRY: CodecRegistry = {
@@ -62,11 +65,12 @@ pub struct Decoder
     thread_killer: Receiver<bool>,
     controls: Controls,
     state: DecoderState,
-    cpal_output: Option<CpalOutput>,
+    cpal_output: CpalOutput,
+    output_writer: Option<OutputWriter>,
     playback: Option<Playback>,
-    preload_playback: Option<(Playback, CpalOutput)>,
+    preload_playback: Option<Playback>,
     /// The `JoinHandle` for the thread that preloads a file.
-    preload_thread: Option<JoinHandle<anyhow::Result<(Playback, CpalOutput)>>>,
+    preload_thread: Option<JoinHandle<anyhow::Result<Playback>>>,
 }
 
 impl Decoder
@@ -75,12 +79,14 @@ impl Decoder
     pub fn new(controls: Controls) -> Self
     {
         let thread_killer = THREAD_KILLER.get().unwrap().read().unwrap().1.clone();
+        let cpal_output = CpalOutput::new(controls.clone()).unwrap();
 
         Decoder {
             thread_killer,
             controls,
             state: DecoderState::Idle,
-            cpal_output: None,
+            cpal_output,
+            output_writer: None,
             playback: None,
             preload_playback: None,
             preload_thread: None,
@@ -161,30 +167,21 @@ impl Decoder
             None => (),
             Some(message) => match message {
                 PlayerEvent::Open(source, buffer_signal) => {
-                    self.cpal_output = None;
+                    self.output_writer = None;
                     self.playback = Some(Self::open(source, buffer_signal)?);
                 }
                 PlayerEvent::Play => {
                     self.state = DecoderState::Playing;
-
-                    // Windows handles play/pause differently.
-                    #[cfg(not(target_os = "windows"))]
-                    if let Some(cpal_output) = &self.cpal_output {
-                        cpal_output.stream.play()?;
-                    }
+                    self.cpal_output.play();
                 }
                 PlayerEvent::Pause => {
                     self.state = DecoderState::Paused;
-
-                    // Windows handles play/pause differently.
-                    #[cfg(not(target_os = "windows"))]
-                    if let Some(cpal_output) = &self.cpal_output {
-                        cpal_output.stream.pause()?;
-                    }
+                    self.cpal_output.pause();
                 }
                 PlayerEvent::Stop => {
                     self.state = DecoderState::Idle;
-                    self.cpal_output = None;
+                    self.cpal_output.pause();
+                    self.output_writer = None;
                     self.playback = None;
                 }
                 // When the device is changed/disconnected,
@@ -193,24 +190,8 @@ impl Decoder
                 // and pause playback. Once the user is ready, they can start
                 // playback themselves.
                 PlayerEvent::DeviceChanged => {
-                    self.cpal_output = None;
+                    self.cpal_output = CpalOutput::new(self.controls.clone())?;
                     Player::internal_pause(&self.controls);
-
-                    // The device change will also affect the preloaded playback.
-                    if self.preload_playback.is_some() {
-                        let (playback, cpal_output) = self.preload_playback.take().unwrap();
-                        let buffer_signal = playback.buffer_signal.clone();
-
-                        self.preload_playback.replace((
-                            playback,
-                            CpalOutput::new(
-                                self.controls.clone(),
-                                buffer_signal,
-                                cpal_output.spec,
-                                cpal_output.duration,
-                            )?,
-                        ));
-                    }
                 }
                 PlayerEvent::Preload(source, buffer_signal) => {
                     self.preload_playback = None;
@@ -223,9 +204,8 @@ impl Decoder
                         return Ok(false);
                     }
 
-                    let (playback, cpal_output) = self.preload_playback.take().unwrap();
+                    let playback = self.preload_playback.take().unwrap();
                     self.playback = Some(playback);
-                    self.cpal_output = Some(cpal_output);
                     self.controls.set_is_file_preloaded(false);
 
                     Player::internal_play(&self.controls);
@@ -253,19 +233,20 @@ impl Decoder
         // then output that instead.
         if let Some(preload) = playback.preload.take() {
             // Write the decoded packet to CPAL.
-            if self.cpal_output.is_none() {
+            if self.output_writer.is_none() {
                 let spec = *preload.spec();
                 let duration = preload.capacity() as u64;
-                self.cpal_output.replace(CpalOutput::new(
+                self.output_writer.replace(OutputWriter::new(
                     self.controls.clone(),
-                    playback.buffer_signal.clone(),
+                    self.cpal_output.ring_buffer_writer.clone(),
+                    self.cpal_output.stream_config.clone(),
                     spec,
                     duration,
-                )?);
+                ));
             }
 
             let buffer_ref = preload.as_audio_buffer_ref();
-            self.cpal_output.as_mut().unwrap().write(buffer_ref);
+            self.output_writer.as_mut().unwrap().write(buffer_ref);
 
             return Ok(false);
         }
@@ -284,9 +265,7 @@ impl Decoder
             playback.decoder.reset();
             // Clear the ring buffer which prevents the writer
             // from blocking.
-            if let Some(cpal_output) = self.cpal_output.as_ref() {
-                cpal_output.ring_buffer_reader.skip_all();
-            }
+            self.cpal_output.ring_buffer_reader.skip_all();
             return Ok(false);
         }
 
@@ -333,18 +312,19 @@ impl Decoder
         self.controls.set_progress(progress);
 
         // Write the decoded packet to CPAL.
-        if self.cpal_output.is_none() {
+        if self.output_writer.is_none() {
             let spec = *decoded.spec();
             let duration = decoded.capacity() as u64;
-            self.cpal_output.replace(CpalOutput::new(
+            self.output_writer.replace(OutputWriter::new(
                 self.controls.clone(),
-                playback.buffer_signal.clone(),
+                self.cpal_output.ring_buffer_writer.clone(),
+                self.cpal_output.stream_config.clone(),
                 spec,
                 duration,
-            )?);
+            ));
         }
 
-        self.cpal_output.as_mut().unwrap().write(decoded);
+        self.output_writer.as_mut().unwrap().write(decoded);
 
         Ok(false)
     }
@@ -354,8 +334,8 @@ impl Decoder
     /// Flushes `cpal_output` and sends a `Done` message to Dart.
     fn finish_playback(&mut self)
     {
-        if let Some(cpal_output) = self.cpal_output.as_mut() {
-            cpal_output.flush();
+        if let Some(output_writer) = self.output_writer.as_mut() {
+            output_writer.flush();
         }
 
         // Send the done message once cpal finishes flushing.
@@ -433,14 +413,13 @@ impl Decoder
 
     /// Spawns a thread that decodes the first packet of the source.
     ///
-    /// Returns a preloaded `Playback` and `CpalOutput` when complete.
+    /// Returns a preloaded `Playback` when complete.
     fn preload(
         &self,
         source: Box<dyn MediaSource>,
         buffer_signal: Arc<AtomicBool>,
-    ) -> JoinHandle<anyhow::Result<(Playback, CpalOutput)>>
+    ) -> JoinHandle<anyhow::Result<Playback>>
     {
-        let controls = self.controls.clone();
         thread::spawn(move || {
             let mut playback = Self::open(source, buffer_signal.clone())?;
             // Preload
@@ -454,12 +433,7 @@ impl Decoder
             buf_ref.convert(&mut buf);
             playback.preload = Some(buf);
 
-            let cpal_output = CpalOutput::new(controls, buffer_signal, spec, duration)?;
-            // Pausing the stream on Windows breaks the output stream.
-            #[cfg(not(target_os = "windows"))]
-            cpal_output.stream.pause()?;
-
-            Ok((playback, cpal_output))
+            Ok(playback)
         })
     }
 

--- a/rust/src/bridge_generated.io.rs
+++ b/rust/src/bridge_generated.io.rs
@@ -71,6 +71,11 @@ pub extern "C" fn wire_play_preload__method__Player(port_: i64, that: *mut wire_
 }
 
 #[no_mangle]
+pub extern "C" fn wire_clear_preload__method__Player(port_: i64, that: *mut wire_Player) {
+    wire_clear_preload__method__Player_impl(port_, that)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_play__method__Player(port_: i64, that: *mut wire_Player) {
     wire_play__method__Player_impl(port_, that)
 }

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -211,6 +211,22 @@ fn wire_play_preload__method__Player_impl(
         },
     )
 }
+fn wire_clear_preload__method__Player_impl(
+    port_: MessagePort,
+    that: impl Wire2Api<Player> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
+        WrapInfo {
+            debug_name: "clear_preload__method__Player",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.wire2api();
+            move |task_callback| Result::<_, ()>::Ok(Player::clear_preload(&api_that))
+        },
+    )
+}
 fn wire_play__method__Player_impl(port_: MessagePort, that: impl Wire2Api<Player> + UnwindSafe) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
         WrapInfo {

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -477,6 +477,7 @@ impl support::IntoDart for PlaybackState {
             Self::Pause => 1,
             Self::Done => 2,
             Self::Stop => 3,
+            Self::PreloadPlayed => 4,
         }
         .into_dart()
     }

--- a/rust/src/utils/types.rs
+++ b/rust/src/utils/types.rs
@@ -18,13 +18,15 @@
 pub enum PlaybackState
 {
     /// The player is currently playing the file.
-    Play = 0,
+    Play,
     /// The player is currently paused and there is no output.
-    Pause = 1,
+    Pause,
     /// The player has finished playing the file.
-    Done = 2,
+    Done,
     /// The player was stopped
-    Stop = 3,
+    Stop,
+    /// The player has automatically started playing the preloaded file.
+    PreloadPlayed,
 }
 
 /// Provides the current progress of the player.


### PR DESCRIPTION
These improvements are based on the following:
- [Symphonia question](https://github.com/pdeljanov/Symphonia/discussions/169#discussioncomment-4395869)
- @Yesterday17's [anni-playback](https://github.com/ProjectAnni/anni/tree/master/anni-playback)

There is now only 1 CpalOutput stream but mutiple writers that write to the ring buffer.

New API symbols:
- `clearPreload()` to clear the preloaded file
- `PlaybackState.preloadPlayed` happens when the preloaded file is automatically played.